### PR TITLE
Add support p2157 to config_flow

### DIFF
--- a/custom_components/dreame_vacuum/config_flow.py
+++ b/custom_components/dreame_vacuum/config_flow.py
@@ -54,6 +54,7 @@ SUPPORTED_MODELS = [
     "dreame.vacuum.p2187",
     "dreame.vacuum.r2228o",
     "dreame.vacuum.r2215o",
+    "dreame.vacuum.p2157",
     #"dreame.vacuum.p2009",
 ]
 


### PR DESCRIPTION
Mova L600 is listed in the readme as supported but not useable since it's not in the supported directory in the config flow