### PR TITLE
Fix for upcoming Version 2023.3

### DIFF
--- a/custom_components/dreame_vacuum/__init__.py
+++ b/custom_components/dreame_vacuum/__init__.py
@@ -27,7 +27,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     entry.async_on_unload(entry.add_update_listener(update_listener))
 
     # Set up all platforms for this device/entry.
-    hass.config_entries.async_setup_platforms(entry, PLATFORMS)
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 


### PR DESCRIPTION
Fix since it will fail in version 2023.3

`WARNING (MainThread) [homeassistant.helpers.frame] Detected integration that called async_setup_platforms instead of awaiting async_forward_entry_setups; this will fail in version 2023.3. Please report issue to the custom integration author for dreame_vacuum using this method at custom_components/dreame_vacuum/__init__.py, line 30: hass.config_entries.async_setup_platforms(entry, PLATFORMS)`

Its working on local.
