### PR TITLE
Add codespell and fix typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,6 @@
 [codespell]
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git,.codespellrc
+skip = .git,.codespellrc,translations,resources.py
 check-hidden = true
 # ignore-regex = 
-# ignore-words-list =
+ignore-words-list = hass,aline

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,23 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ wget -O - https://raw.githubusercontent.com/Tasshack/dreame-vacuum/dev/install |
 <a href="https://my.home-assistant.io/redirect/config_flow_start/?domain=dreame_vacuum" target="_blank"><img src="https://my.home-assistant.io/badges/config_flow_start.svg" alt="Open your Home Assistant instance and start setting up a new integration." /></a>
 - Select configuration type:
 
-     - **Mi Home Acccount**: TODO
+     - **Mi Home Account**: TODO
      - **Dreamehome Account**: TODO
      - **Local**: TODO
 

--- a/custom_components/dreame_vacuum/dreame/device.py
+++ b/custom_components/dreame_vacuum/dreame/device.py
@@ -2935,7 +2935,7 @@ class DreameVacuumDevice:
             or len(voice_assistant_language) < 2
             or voice_assistant_language.upper() not in DreameVacuumVoiceAssistantLanguage.__members__
         ):
-            raise InvalidActionException(f"Voice assistant language ({voice_assistant_language}) is not suported")
+            raise InvalidActionException(f"Voice assistant language ({voice_assistant_language}) is not supported")
         return self.set_property(
             DreameVacuumProperty.VOICE_ASSISTANT_LANGUAGE,
             DreameVacuumVoiceAssistantLanguage[voice_assistant_language.upper()],
@@ -3935,7 +3935,7 @@ class DreameVacuumDevice:
                 result = self.set_auto_switch_settings({"k": prop.value, "v": int(value)})
                 if result is None or result[0]["code"] != 0:
                     _LOGGER.error(
-                        "Auto Swtich Property not updated: %s: %s -> %s",
+                        "Auto Switch Property not updated: %s: %s -> %s",
                         prop.name,
                         current_value,
                         value,

--- a/docs/map.md
+++ b/docs/map.md
@@ -499,7 +499,7 @@ Map will be rendered at 1:1 ratio when this option is enabled from configuration
 
 ### Low Resolution Map
 
-Low resolution configuration option must be enabled when Home Assistant instace running on a system or container with less than 3GB memory otherwise Home Assistance instance may not start since integration uses a lot of memory for rendering zoomable high resolution images like official APP.
+Low resolution configuration option must be enabled when Home Assistant instance running on a system or container with less than 3GB memory otherwise Home Assistance instance may not start since integration uses a lot of memory for rendering zoomable high resolution images like official APP.
 
 
 ### <a href="https://github.com/Tasshack/dreame-vacuum/blob/master/README.md#how-to-use" target="_blank">How to view the map on the dashboard</a>

--- a/docs/services.md
+++ b/docs/services.md
@@ -448,7 +448,7 @@ Rename a map.
 ### `dreame_vacuum.vacuum_restore_map`
 
 Restore a map from previous state that are created and uploaded by the device.
-> - It is not guaranteed that map recovery will be successfull. Cloud does not store the files forever and recovery files usually be deleted from the cloud after 365 days from the last access.
+> - It is not guaranteed that map recovery will be successful. Cloud does not store the files forever and recovery files usually be deleted from the cloud after 365 days from the last access.
 >  - Cloud connection is required with this service.
 
 **Examples:**


### PR DESCRIPTION
reincarnated
- https://github.com/Tasshack/dreame-vacuum/pull/423

but against `dev`. As it shows -- the other tool isn't as good I guess since typos are still found