### PR TITLE
Refined German Translations

### DIFF
--- a/custom_components/dreame_vacuum/translations/de.json
+++ b/custom_components/dreame_vacuum/translations/de.json
@@ -18,7 +18,7 @@
         "data": {
           "configuration_type": "Konfigurationstyp"
         },
-        "description": "Die Kartenfunktion erfordert eine Cloud-Verbindung und bietet eine automatische Konfiguration. Wenn du die Kartenfunktion nicht verwenden möchtest, kannst du die manuelle Konfiguration wählen."
+        "description": "Die Kartenfunktion erfordert eine Cloudverbindung und bietet eine automatische Konfiguration. Wenn du die Kartenfunktion nicht verwenden möchtest, kannst du die manuelle Konfiguration wählen."
       },
       "local": {
         "data": {
@@ -32,7 +32,7 @@
           "username": "Benutzername",
           "password": "Passwort",
           "country": "Cloudserver",
-          "prefer_cloud": "Cloud-Verbindung bevorzugen"
+          "prefer_cloud": "Cloudverbindung bevorzugen"
         },
         "description": "Melde dich bei der Xiaomi Miio Cloud an, siehe https://www.openhab.org/addons/bindings/miio/#country-servers für den zu verwendenden Cloud-Server."
       },
@@ -78,7 +78,7 @@
           "low_resolution": "Karte mit niedriger Auflösung",
           "square": "Quadratische Karte",
           "configuration_type": "Konfigurationstyp",
-          "prefer_cloud": "Cloud-Verbindung bevorzugen"
+          "prefer_cloud": "Cloudverbindung bevorzugen"
         }
       }
     },
@@ -221,14 +221,14 @@
       "auto_recleaning": {
         "state": {
           "off": "Aus",
-          "in_deep_mode": "Im Deep-Modus",
+          "in_deep_mode": "Bei gründlicher Reinigung",
           "in_all_modes": "In allen Modi"
         }
       },
       "auto_rewashing": {
         "state": {
           "off": "Aus",
-          "in_deep_mode": "Im Deep-Modus",
+          "in_deep_mode": "Bei gründlicher Reinigung",
           "in_all_modes": "In allen Modi"
         }
       },
@@ -315,8 +315,8 @@
           "room_cleaning": "Raumreinigung",
           "zone_cleaning": "Zonenreinigung",
           "fast_mapping": "Schnelles Mapping",
-          "cruising_path": "Cruising auf dem Weg",
-          "cruising_point": "Eine Kreuzfahrt zu einem Punkt",
+          "cruising_path": "Fährt auf Wegstrecke",
+          "cruising_point": "Auf dem Weg zum Zielpunkt",
           "summon_clean": "Zur Reinigung rufen",
           "shortcut": "Verknüpfung",
           "person_follow": "Person folgen",
@@ -343,13 +343,13 @@
           "room_mopping_paused": "Raumwischen pausiert",
           "zone_docking_paused": "Zonenwischen pausiert",
           "room_docking_paused": "Raumdocking pausiert",
-          "cruising_path": "Cruising auf dem Weg",
-          "cruising_path_paused": "Die Fahrt wurde auf dem Weg unterbrochen",
-          "cruising_point": "Eine Fahrt zu einem Punkt",
-          "cruising_point_paused": "Die Fahrt zu einem Punkt wurde unterbrochen",
+          "cruising_path": "Fährt auf Wegstrecke",
+          "cruising_path_paused": "Die Fahrt auf der Wegstrecke wurde unterbrochen",
+          "cruising_point": "Auf dem Weg zum Zielpunkt",
+          "cruising_point_paused": "Die Fahrt zum Zielpunkt wurde unterbrochen",
           "summon_clean_paused": "Zur Reinigung rufen wurde angehalten",
-          "returning_to_install_mop": "Zurückkehren zum Installieren des Wischpads",
-          "returning_to_remove_mop": "Zurückkehren zum Entfernen des Wischpads"
+          "returning_to_install_mop": "Zurückkehren zum anbringen des Wischpads",
+          "returning_to_remove_mop": "Zurückkehren zum entfernen des Wischpads"
         }
       },
       "water_tank": {
@@ -402,7 +402,7 @@
           "box_full": "Der Filter ist nicht trocken oder verstopft",
           "brush": "Die Hauptbürste ist eingewickelt",
           "side_brush": "Die Seitenbürste ist eingewickelt",
-          "fan": "Der Filter ist nicht trocken oder verstopft",
+          "fan": "Der Filter ist feucht oder verstopft",
           "left_wheel_motor": "Der Roboter steckt fest, oder sein linkes Rad ist möglicherweise durch Fremdkörper blockiert",
           "right_wheel_motor": "Der Roboter steckt fest, oder sein rechtes Rad ist möglicherweise durch Fremdkörper blockiert",
           "turn_suffocate": "Der Roboter steckt fest oder kann sich nicht drehen",
@@ -415,15 +415,15 @@
           "camera_occlusion": "Fehler des visuellen Positionssensors",
           "move": "Fehler des Bewegungssensors",
           "flow_shielding": "Optischer Sensorfehler",
-          "infrared_shielding": "Infrarotabschirmung Fehler",
+          "infrared_shielding": "Fehler in der Infrarotabschirmung",
           "charge_no_electric": "Die Ladestation ist nicht eingeschaltet",
           "battery_fault": "Batterie Fehler",
           "fan_speed": "Fehler des Lüfterdrehzahlsensors",
           "left_wheell_speed": "Linkes Rad ist möglicherweise durch Fremdkörper blockiert",
           "right_wheell_speed": "Rechtes Rad ist möglicherweise durch Fremdkörper blockiert",
-          "bmi055_acce": "Beschleunigungssensor Fehler",
-          "bmi055_gyro": "Beschleunigungssensor Fehler",
-          "xv7001": "Beschleunigungssensor Fehler",
+          "bmi055_acce": "Fehler im Beschleunigungssensor ",
+          "bmi055_gyro": "Fehler im Beschleunigungssensor",
+          "xv7001": "Fehler im Beschleunigungssensor",
           "left_magnet": "Fehler des linken Magnetsensors",
           "right_magnet": "Fehler des rechten Magnetsensors",
           "flow_error": "Durchflusssensor Fehler",
@@ -436,9 +436,9 @@
           "p3v3": "Interner Fehler",
           "camera_idle": "Interner Fehler",
           "blocked": "Reinigungsroute ist blockiert kehre zur Dock zurück",
-          "lds_error": "Laserentfernungssensors Fehler",
-          "lds_bumper": "Laserentfernungssensors (Bumper) Fehler",
-          "filter_blocked": "Der Filter ist nicht trocken oder verstopft",
+          "lds_error": "Fehler im Laserentfernungssensor",
+          "lds_bumper": "Fehler im Laserentfernungssensor (Bumper)",
+          "filter_blocked": "Der Filter ist feucht oder verstopft",
           "edge": "Kantensensor Fehler",
           "carpet": "Bitte den Roboter in einem Bereich ohne Teppich starten.",
           "laser": "Der 3D-Hindernisvermeidungssensor ist defekt.",
@@ -447,18 +447,18 @@
           "route": "Die Reinigungsroute ist blockiert.",
           "restricted": "Es wurde festgestellt, dass sich der Staubsauger in einem Sperrgebiet befindet.",
           "remove_mop": "Wischen abgeschlossen. Bitte das Wischpad rechtzeitig entfernen und reinigen.",
-          "mop_removed": "Der Wischpad hat sich während der Reinigung gelöst.",
-          "mop_pad_stop_rotate": "Der Wischpad dreht sich nicht mehr",
-          "bin_full": "Der Staubsammelbeutel ist voll, oder der Luftkanal ist verstopft.",
-          "bin_open": "Die obere Abdeckung des automatischen Leergutbehälters ist nicht geschlossen, oder der Staubbeutel ist nicht installiert.",
+          "mop_removed": "Das Wischpad hat sich während der Reinigung gelöst.",
+          "mop_pad_stop_rotate": "Das Wischpad dreht sich nicht mehr",
+          "bin_full": "Der Staubsaugerbeutel ist voll, oder der Luftkanal ist verstopft.",
+          "bin_open": "Die obere Abdeckung der Ladestation ist nicht geschlossen, oder der Staubsaugerbeutel ist nicht installiert.",
           "water_tank": "Der Frischwassertank ist nicht installiert.",
           "dirty_water_tank": "Der Schmutzwassertank ist voll oder nicht installiert.",
           "water_tank_dry": "Niedriger Wasserstand im Frischwassertank, bitte rechtzeitig Wasser nachfüllen.",
           "dirty_water_tank_blocked": "Schmutzwassertank blockiert.",
           "dirty_water_tank_pump": "Schmutzwassertank Pumpenfehler.",
-          "mop_pad": "Der Wischpad ist nicht richtig installiert.",
+          "mop_pad": "Das Wischpad ist nicht richtig installiert.",
           "wet_mop_pad": "Der Wasserstand des Wischpads ist ungewöhnlich, bitte den Wischpad rechtzeitig reinigen.",
-          "clean_mop_pad": "Die Reinigungsaufgabe ist abgeschlossen, bitte den Wischpad reinigen.",
+          "clean_mop_pad": "Die Reinigungsaufgabe ist abgeschlossen, bitte das Wischpad reinigen.",
           "clean_tank_level": "Bitte den Frischwassertank umgehend überprüfen und nachfüllen.",
           "station_disconnected": "Basisstation nicht eingeschaltet",
           "dirty_tank_level": "Der Wasserstand im Schmutzwassertank ist zu hoch.",
@@ -467,9 +467,9 @@
           "dust_bag_full": "Der Staubbeutel ist voll oder die Lüftungsschlitze sind blockiert.",
           "self_test_failed": "Ungewöhnlicher Wasseraustritt aus dem Frischwassertank des oberen und unteren Wassermoduls.",
           "mop_install_failed": "Die Installation des Wischpads ist fehlgeschlagen.",
-          "low_battery_turn_off": "Niedriger Batteriestatus. ",
-          "dirty_tank_not_installed": "Der Altwassertank des Roboters ist nicht installiert.",
-          "robot_in_hidden_room": "Versteckter Bereich. ",
+          "low_battery_turn_off": "Niedriger Batteriestatus.",
+          "dirty_tank_not_installed": "Der Schmutzwassertank des Roboters ist nicht installiert.",
+          "robot_in_hidden_room": "Roboter im versteckten Bereich. Bitte aus dem Bereich entfernen und erneut versuchen.",
           "washboard_not_working": "Waschbrett funktioniert nicht mehr.",
           "return_to_charge_failed": "Rückkehr zum Laden fehlgeschlagen."
         }
@@ -499,7 +499,7 @@
           "washing": "Waschen",
           "drying": "Trocknen",
           "paused": "Pausiert",
-          "returning": "Zurückkehren zum Waschen",
+          "returning": "Zurückkehren zum Reinigen",
           "clean_add_water": "Reinigung und Wasser nachfüllen",
           "adding_water": "Wasser nachfüllen"
         }
@@ -511,7 +511,7 @@
           "no_water_left": "Das Wasser im Frischwassertank ist bald aufgebraucht.",
           "no_water_left_after_clean": "Wischpad wurde gereinigt.",
           "no_water_for_clean": "Niedriger Wasserstand im Frischwassertank.",
-          "low_water": "Das Wasser geht mir bald aus.",
+          "low_water": "Der Wasserstand ist niedrig. Bitte den Frischwassertank auffüllen",
           "tank_not_installed": "Der Frischwassertank ist nicht installiert."
         }
       },
@@ -521,7 +521,7 @@
           "idle": "Leerlauf",
           "video": "Video",
           "audio": "Audio",
-          "recording": "Aufzeichnung"
+          "recording": "Aufnahme"
         }
       },
       "drainage_status": {
@@ -530,22 +530,22 @@
           "idle": "Leerlauf",
           "draining": "Entleeren",
           "draining_successful": "Entleerung erfolgreich",
-          "draining_failed": "Das Entleeren ist fehlgeschlagen"
+          "draining_failed": "Die Entleerung ist fehlgeschlagen"
         }
       },
       "task_type": {
         "state": {
           "standard": "Standardreinigung",
           "standard_paused": "Standardreinigung angehalten",
-          "custom": "Individuelle Reinigung",
+          "custom": "Benutzerdefinierte Reinigung",
           "custom_paused": "Benutzerdefinierte Reinigung angehalten",
-          "shortcut": "Abkürzungsreinigung",
-          "shortcut_paused": "Verknüpfungsreinigung angehalten",
+          "shortcut": "Schnellreinigung",
+          "shortcut_paused": "Schnellreinigung angehalten",
           "scheduled": "Geplante Reinigung",
           "scheduled_paused": "Geplante Reinigung pausiert",
           "smart": "Intelligente Reinigung",
           "smart_paused": "Intelligente Reinigung pausiert",
-          "partial": "Teilweise Reinigung",
+          "partial": "Teilreinigung",
           "partial_paused": "Teilreinigung pausiert",
           "summon": "Zur Reinigung heranrufen",
           "summon_paused": "Reinigung herbeirufen pausiert",
@@ -601,7 +601,7 @@
       }
     },
     "vacuum_clean_spot": {
-      "name": "Punkt reinigen",
+      "name": "Punktreinigung",
       "description": "Starte den Reinigungsvorgang an den ausgewählten Punkten auf der Karte.",
       "fields": {
         "points": {
@@ -623,8 +623,8 @@
       }
     },
     "vacuum_goto": {
-      "name": "Gehe zu",
-      "description": "Gehe zu den Koordinaten auf der Karte und stoppe.",
+      "name": "Fahre zu",
+      "description": "Fahre zu den Koordinaten auf der Karte und stoppe.",
       "fields": {
         "x": {
           "name": "X",
@@ -637,8 +637,8 @@
       }
     },
     "vacuum_follow_path": {
-      "name": "Pfad verfolgen",
-      "description": "Folge einer Liste von Koordinaten auf der Karte und kehre zur Basis zurück. (Nur bei Staubsaugern mit Kamera unterstützt)",
+      "name": "Pfad folgen",
+      "description": "Folge einer Liste von Koordinaten auf der Karte und kehre zur Basis zurück. (unterstützt nur bei Staubsaugern mit Kamera)",
       "fields": {
         "points": {
           "name": "Punkte",
@@ -647,7 +647,7 @@
       }
     },
     "vacuum_remote_control_move_step": {
-      "name": "Schrittweise Fernbedienung",
+      "name": "Schrittweise Fernsteuerung",
       "description": "Bewege den Roboter ferngesteuert einen Schritt.",
       "fields": {
         "rotation": {
@@ -768,7 +768,7 @@
     },
     "vacuum_backup_map": {
       "name": "Backup-Karte",
-      "description": "Sichern Sie eine Karte in der Cloud.",
+      "description": "Sichern einer Karte in die Cloud.",
       "fields": {
         "map_id": {
           "name": "Karten-ID",
@@ -824,7 +824,7 @@
     },
     "vacuum_set_cleaning_sequence": {
       "name": "Reihenfolge der Reinigung festlegen",
-      "description": "Reihenfolge der Raumreinigung festlegen. (Nur bei unterstützten Geräten)",
+      "description": "Reihenfolge der Raumreinigung festlegen (nur bei unterstützten Geräten).",
       "fields": {
         "cleaning_sequence": {
           "name": "Reinigungsreihenfolge",
@@ -834,7 +834,7 @@
     },
     "vacuum_set_custom_cleaning": {
       "name": "Benutzerdefinierte Reinigung festlegen",
-      "description": "Benutzerdefinierte Reinigungsparameter festlegen. (Nur bei unterstützten Geräten)",
+      "description": "Benutzerdefinierte Reinigungsparameter festlegen (nur bei unterstützten Geräten).",
       "fields": {
         "segment_id": {
           "name": "Segment-ID",
@@ -850,7 +850,7 @@
         },
         "cleaning_mode": {
           "name": "Reinigungsmodus",
-          "description": "Reinigungsmodus für jeden Raum (nur bei Staubsaugern mit Wischpad-Hebefunktion unterstützt)."
+          "description": "Reinigungsmodus für jeden Raum (unterstützt nur bei Staubsaugern mit Wischpad-Hebefunktion)."
         },
         "repeats": {
           "name": "Wiederholungen",
@@ -888,7 +888,7 @@
     },
     "vacuum_rename_shortcut": {
       "name": "Verknüpfung umbenennen",
-      "description": "Benenne eine Verknüpfung um. (Nur bei unterstützten Geräten)",
+      "description": "Benenne eine Verknüpfung um (nur bei unterstützten Geräten).",
       "fields": {
         "shortcut_id": {
           "name": "Verknüpfungs-ID",
@@ -902,7 +902,7 @@
     },
     "vacuum_set_carpet_area": {
       "name": "Teppichbereich festlegen",
-      "description": "Teppiche und ignorierte Teppiche definieren. (Nur bei unterstützten Geräten)",
+      "description": "Teppiche und ignorierte Teppiche definieren (nur bei unterstützten Geräten).",
       "fields": {
         "carpets": {
           "name": "Teppiche",
@@ -926,7 +926,7 @@
     },
     "vacuum_set_predefined_points": {
       "name": "Vordefinierte Punkte festlegen",
-      "description": "Vordefinierte Koordinaten auf der aktuellen Karte festlegen. (Nur bei Staubsaugern mit Kamera unterstützt)",
+      "description": "Vordefinierte Koordinaten auf der aktuellen Karte festlegen (nur unterstützt bei Staubsaugern mit Kamera).",
       "fields": {
         "points": {
           "name": "Punkte",
@@ -936,7 +936,7 @@
     },
     "vacuum_set_obstacle_ignore": {
       "name": "Hindernis ignorieren festlegen",
-      "description": "Den Ignorierstatus eines Hindernisses festlegen. (Nur bei Staubsaugern mit AI-Hinderniserkennungsfunktion unterstützt)",
+      "description": "Den Ignorierstatus eines Hindernisses festlegen (nur unterstützt bei Staubsaugern mit AI-Hinderniserkennungsfunktion).",
       "fields": {
         "x": {
           "name": "X",
@@ -954,7 +954,7 @@
     },
     "vacuum_set_router_position": {
       "name": "Routerposition festlegen",
-      "description": "Die Position des Routers auf der aktuellen Karte festlegen. (Nur bei Staubsaugern mit WLAN-Kartierungsfunktion unterstützt)",
+      "description": "Die Position des Routers auf der aktuellen Karte festlegen (nur unterstützt bei Staubsaugern mit WLAN-Kartierungsfunktion).",
       "fields": {
         "x": {
           "name": "X",


### PR DESCRIPTION
Hello,

I fixed some translation mistakes in the German translation, so a German user could better understand what is meant in different parts of the component.

E.g. renamed "Fernbedienung" to "Fernsteuerung", fixed the article of "Wischpad" ("das" instead of "der") etc.

Hope I could help and greetings from Germany.