### PR TITLE
add 2228z as an alternative to 2228o

### DIFF
--- a/custom_components/dreame_vacuum/config_flow.py
+++ b/custom_components/dreame_vacuum/config_flow.py
@@ -65,6 +65,7 @@ DREAME_MODELS = [
     "dreame.vacuum.r2228",
     "dreame.vacuum.r2228d",
     "dreame.vacuum.r2228o",
+    "dreame.vacuum.r2228z",
     "dreame.vacuum.r2232a",
     "dreame.vacuum.r2232b",
     "dreame.vacuum.r2232c",


### PR DESCRIPTION
An L10s Ultra from 6 months ago worked fine (2228o), but a newly bought one, from the very same Amazon listing, same make and model, turned out to be a 2228z