### PR TITLE
Checking if history.neglected_segments is a dict

### DIFF
--- a/custom_components/dreame_vacuum/dreame/device.py
+++ b/custom_components/dreame_vacuum/dreame/device.py
@@ -7029,7 +7029,7 @@ class DreameVacuumDeviceStatus:
                             .replace("_", " ")
                             .capitalize()
                         )
-                    if history.neglected_segments:
+                    if isinstance(history.neglected_segments, dict):
                         list[date][ATTR_NEGLECTED_SEGMENTS] = {
                             k: v.name.replace("_", " ").capitalize() for k, v in history.neglected_segments.items()
                         }


### PR DESCRIPTION
Sometimes, `history.neglected_segments` is returned as a string that looks like `[]` instead of a dictionary, causing the integration to fail with an error:
```
2025-02-27 14:31:47.990 ERROR (MainThread) [homeassistant] Error doing job: Exception in callback DreameVacuumDataUpdateCoordinator.async_set_updated_data() (None)
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/asyncio/events.py", line 89, in _run
    self._context.run(self._callback, *self._args)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/dreame_vacuum/coordinator.py", line 493, in async_set_updated_data
    super().async_set_updated_data(self._device)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 515, in async_set_updated_data
    self.async_update_listeners()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/update_coordinator.py", line 178, in async_update_listeners
    update_callback()
    ~~~~~~~~~~~~~~~^^
  File "/config/custom_components/dreame_vacuum/entity.py", line 151, in _handle_coordinator_update
    self.async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1023, in async_write_ha_state
    self._async_write_ha_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1148, in _async_write_ha_state
    self.__async_calculate_state()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 1089, in __async_calculate_state
    if extra_state_attributes := self.extra_state_attributes:
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/dreame_vacuum/entity.py", line 211, in extra_state_attributes
    attrs = self.entity_description.attrs_fn(self.device)
  File "/config/custom_components/dreame_vacuum/sensor.py", line 383, in <lambda>
    attrs_fn=lambda device: device.status.cleaning_history,
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/config/custom_components/dreame_vacuum/dreame/device.py", line 7034, in cleaning_history
    k: v.name.replace("_", " ").capitalize() for k, v in history.neglected_segments.items()
                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'items'
```

That happens because the code uses:

```python
k: v.name.replace("_", " ").capitalize() for k, v in history.neglected_segments.items()
```

which only works if `neglected_segments` is a dictionary. When `neglected_segments` is a string, calling `.items()` raises an `AttributeError`.

This PR just adds a check to ensure `history.neglected_segments` is indeed a dictionary before calling `.items()`.