### PR TITLE
Fix translation key for fan speed error in German locale

### DIFF
--- a/custom_components/dreame_vacuum/translations/de.json
+++ b/custom_components/dreame_vacuum/translations/de.json
@@ -418,7 +418,7 @@
           "infrared_shielding": "Fehler in der Infrarotabschirmung",
           "charge_no_electric": "Die Ladestation ist nicht eingeschaltet",
           "battery_fault": "Batterie Fehler",
-          "fan_speed": "Fehler des Lüfterdrehzahlsensors",
+          "fan_speed_error": "Fehler des Lüfterdrehzahlsensors",
           "left_wheell_speed": "Linkes Rad ist möglicherweise durch Fremdkörper blockiert",
           "right_wheell_speed": "Rechtes Rad ist möglicherweise durch Fremdkörper blockiert",
           "bmi055_acce": "Fehler im Beschleunigungssensor ",


### PR DESCRIPTION
Updated the key from "fan_speed" to "fan_speed_error" in the German translation file to ensure consistency and accuracy. No other changes were made to the file.