### PR TITLE
Add dutch translation

### DIFF
--- a/custom_components/dreame_vacuum/translations/nl.json
+++ b/custom_components/dreame_vacuum/translations/nl.json
@@ -480,8 +480,8 @@
           "description": "Hoeveelheid schoonmaak herhalingen voor elke geselecteerde kamer. (Tenzij overschreven door aangepaaste schoonmaak parameter)."
         },
         "suction_level": {
-          "name": "Zuig niveau",
-          "description": "Zuig snelheid voor voor elke geselecteerde kamer. (Tenzij overschreven door aangepaaste schoonmaak parameter)."
+          "name": "zuigkracht",
+          "description": "zuigkracht voor voor elke geselecteerde kamer. (Tenzij overschreven door aangepaaste schoonmaak parameter)."
         },
         "water_volume": {
           "name": "Water volume",
@@ -502,8 +502,8 @@
           "description": "Hoeveelheid schoonmaak herhalingen voor elke geselecteerde zone."
         },
         "suction_level": {
-          "name": "Zuig niveau",
-          "description": "Zuig snelheid voor voor elke geselecteerde zone."
+          "name": "zuigkracht",
+          "description": "zuigkracht voor voor elke geselecteerde zone."
         },
         "water_volume": {
           "name": "Water Volume",
@@ -524,8 +524,8 @@
           "description": "Hoeveelheid schoonmaak herhalingen voor elke geselecteerde zone."
         },
         "suction_level": {
-          "name": "Suction Level",
-          "description": "Zuig snelheid voor voor elke geselecteerde zone."
+          "name": "Zuigkracht",
+          "description": "zuigkracht voor voor elke geselecteerde zone."
         },
         "water_volume": {
           "name": "Water Volume",


### PR DESCRIPTION
I completly translated the en.json to the dutch (NL) version. 

The only part for me that was difficult to understand was the translation suction/fan speed/level. In the english version fan and suction was somtimes mixed around. For example:
        "suction_level": {
          "name": "Suction Level",
          "description": "Fan speed for every selected zone."
Fan speed felt off for me when talking about suction so I changed it to:

        "suction_level": {
          "name": "Suction Level",
          "description": "Suction strength for every selected zone."
But then in Dutch ofcourse. 
          

