### PR TITLE
Fix JSON serialization error while using LTSS

### DIFF
--- a/custom_components/dreame_vacuum/dreame/types.py
+++ b/custom_components/dreame_vacuum/dreame/types.py
@@ -5,7 +5,7 @@ import json
 import time
 from typing import Any, Dict, Final, List, Optional
 from enum import IntEnum, Enum
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from datetime import datetime
 
 SEGMENT_TYPE_CODE_TO_NAME: Final = {
@@ -3748,7 +3748,10 @@ class Shortcut:
     map_id: int = None
     running: bool = False
     tasks: list[list[ShortcutTask]] = None
-
+    
+    def as_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+    
 
 @dataclass
 class ShortcutTask:
@@ -3757,6 +3760,9 @@ class ShortcutTask:
     water_volume: int = None
     cleaning_times: int = None
     cleaning_mode: int = None
+
+    def as_dict(self) -> Dict[str, Any]:
+        return asdict(self)
 
 
 @dataclass
@@ -3772,7 +3778,10 @@ class ScheduleTask:
     water_volume: int = None
     options: str = None
 
-
+    def as_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+    
+    
 @dataclass
 class GoToZoneSettings:
     x: int = None
@@ -3783,6 +3792,9 @@ class GoToZoneSettings:
     cleaning_mode: int = None
     size: int = 50
 
+    def as_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+    
 
 @dataclass
 class MapRendererConfig:


### PR DESCRIPTION
## Description
This PR adds `as_dict()` methods to some data classes to make them JSON serializable, resolving the TypeError that occurs when the LTSS custom component attempts to save state data.

## Issue
When using the LTSS plugin for long-term state storage, the following error occurs:

```
2025-08-11 12:11:30.825 ERROR (LTSS) [custom_components.ltss] Error saving batch of 100 events
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/sqlalchemy/engine/base.py", line 1811, in _execute_context
    context = constructor(
        dialect, self, conn, execution_options, *args, **kw
    )
  File "/usr/local/lib/python3.13/site-packages/sqlalchemy/engine/default.py", line 1519, in _init_compiled
    flattened_processors[key](compiled_params[key])
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/sqlalchemy/sql/sqltypes.py", line 2792, in process
    return json_serializer(value)
  File "/config/custom_components/ltss/__init__.py", line 367, in <lambda>
    json_serializer=lambda obj: json.dumps(obj, cls=JSONEncoder),
                                ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/json/__init__.py", line 238, in dumps
    **kw).encode(obj)
          ~~~~~~^^^^^
  File "/usr/local/lib/python3.13/json/encoder.py", line 200, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/local/lib/python3.13/json/encoder.py", line 261, in iterencode
    return _iterencode(o, 0)
  File "/usr/src/homeassistant/homeassistant/helpers/json.py", line 67, in default
    return json.JSONEncoder.default(self, o)
           ~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/usr/local/lib/python3.13/json/encoder.py", line 180, in default
    raise TypeError(f'Object of type {o.__class__.__name__} '
                    f'is not JSON serializable')
TypeError: Object of type ShortcutTask is not JSON serializable
```
