### PR TITLE
Improve Dutch translations in nl.json

### DIFF
--- a/custom_components/dreame_vacuum/translations/nl.json
+++ b/custom_components/dreame_vacuum/translations/nl.json
@@ -141,10 +141,10 @@
       },
       "cleaning_mode": {
         "state": {
-          "sweeping": "Vegen",
+          "sweeping": "Stofzuigen",
           "mopping": "Dweilen",
-          "sweeping_and_mopping": "Vegen en dweilen",
-          "mopping_after_sweeping": "Dweilen na vegen"
+          "sweeping_and_mopping": "Stofzuigen en dweilen",
+          "mopping_after_sweeping": "Dweilen na stofzuigen"
         }
       },
       "carpet_sensitivity": {
@@ -317,7 +317,7 @@
       "state": {
         "state": {
           "unknown": "Onbekend",
-          "sweeping": "Vegen",
+          "sweeping": "Stofzuigen",
           "charging": "Opladen",
           "error": "Fout",
           "idle": "Inactief",
@@ -328,7 +328,7 @@
           "washing": "Wassen",
           "returning_to_wash": "Terugkeren om te wassen",
           "building": "Bouwen",
-          "sweeping_and_mopping": "Vegen en dweilen",
+          "sweeping_and_mopping": "Stofzuigen en dweilen",
           "charging_completed": "Opladen voltooid",
           "upgrading": "Upgraden",
           "clean_summon": "Oproepen om schoon te maken",


### PR DESCRIPTION
Improved clarity in Dutch translations.

The word 'sweeping' has been changed to 'vacuuming'.
The robot vacuum cleaner does not sweep; it vacuums.