### PR TITLE
Allow water tank draining without mop pads installed

### DIFF
--- a/custom_components/dreame_vacuum/dreame/device.py
+++ b/custom_components/dreame_vacuum/dreame/device.py
@@ -4448,8 +4448,7 @@ class DreameVacuumDevice:
         if clean_water_tank:
             if self.capability.empty_water_tank:
                 return self.start_self_wash_base("9,1")
-        if self.status.washing_available and self.status.drying_available:
-            return self.start_self_wash_base("7,1")
+        return self.start_self_wash_base("7,1")
 
     def start_self_repairing(self) -> dict[str, Any] | None:
         """Start self repairing if self-wash base is present."""


### PR DESCRIPTION
When I drain the robot's internal tank to refresh it, I always remove the mop pads. This change fixes the ability to run drainage when the mop pads are removed, just like in the official app.