### PR TITLE
Fix `Empty Water Tank` function

### DIFF
--- a/custom_components/dreame_vacuum/button.py
+++ b/custom_components/dreame_vacuum/button.py
@@ -221,7 +221,8 @@ BUTTONS: tuple[ButtonEntityDescription, ...] = (
         icon="mdi:waves-arrow-up",
         entity_category=EntityCategory.DIAGNOSTIC,
         action_fn=lambda device: device.start_draining(True),
-        exists_fn=lambda description, device: device.capability.self_wash_base and device.capability.empty_water_tank,
+        exists_fn=lambda description, device: device.capability.self_wash_base
+        and (device.capability.empty_water_tank or device.capability.ultra_clean_mode),
     ),
     DreameVacuumButtonEntityDescription(
         key="base_station_self_repair",

--- a/custom_components/dreame_vacuum/dreame/device.py
+++ b/custom_components/dreame_vacuum/dreame/device.py
@@ -4446,8 +4446,7 @@ class DreameVacuumDevice:
     def start_draining(self, clean_water_tank=False) -> dict[str, Any] | None:
         """Start draining water if self-wash base is present."""
         if clean_water_tank:
-            if self.capability.empty_water_tank:
-                return self.start_self_wash_base("9,1")
+            return self.start_self_wash_base("9,1")
         if self.status.washing_available and self.status.drying_available:
             return self.start_self_wash_base("7,1")
 

--- a/custom_components/dreame_vacuum/dreame/types.py
+++ b/custom_components/dreame_vacuum/dreame/types.py
@@ -1885,8 +1885,8 @@ ACTION_AVAILABILITY: Final = {
     and not device.status.drying
     and not device.status.auto_emptying,
     "start_recleaning": lambda device: not device.status.started and device.status.second_cleaning_available,
-    "empty_water_tank": lambda device: not device.draining
-    and device.docked
+    "empty_water_tank": lambda device: not device.status.draining
+    and device.status.docked
     and not device.status.self_repairing
     and not device.status.washing,
 }


### PR DESCRIPTION
Fixes: https://github.com/Tasshack/dreame-vacuum/issues/1077

This PR adds/fixes support for draining the [external automatic water supply and drainage module](https://www.dreametech.com/pages/water_hookup_kit_raw4_installation_guide). 

It looks like this functionality was under development, as due to a typo in the code it was unlikely to work for anyone.

I wasn’t able to find any reference in the code where capability `device.capability.empty_water_tank` from the API is verified, nor a capability that detects the presence of an external water tank module. Therefore, I decided to rely on the `ultra_clean_mode` capability, which only appears when this module is present.

Tested on L10s Pro Ultra Heat with Dreame Kit RAW6.