### PR TITLE
Migrate integration to has entity name

### DIFF
--- a/custom_components/dreame_vacuum/entity.py
+++ b/custom_components/dreame_vacuum/entity.py
@@ -74,6 +74,8 @@ class DreameVacuumEntityDescription:
 class DreameVacuumEntity(CoordinatorEntity[DreameVacuumDataUpdateCoordinator]):
     """Defines a base Dreame Vacuum entity."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: DreameVacuumDataUpdateCoordinator,
@@ -137,7 +139,7 @@ class DreameVacuumEntity(CoordinatorEntity[DreameVacuumDataUpdateCoordinator]):
             if self.entity_description.name_fn is not None:
                 name = self.entity_description.name_fn(self.native_value, self.device)
 
-            self._attr_name = f"{self.device.name} {name}"
+            self._attr_name = name
 
     def _generate_entity_id(self, format) -> None:
         if self.entity_description.key:

--- a/custom_components/dreame_vacuum/vacuum.py
+++ b/custom_components/dreame_vacuum/vacuum.py
@@ -675,9 +675,7 @@ class DreameVacuum(DreameVacuumEntity, StateVacuumEntity):
         super().__init__(coordinator)
 
         self._attr_device_class = DOMAIN
-        self._attr_name = (
-            f" {coordinator.device.name}"  ## Add whitespace to display entity on top at the device configuration page
-        )
+        self._attr_name = None
         self._attr_unique_id = f"{coordinator.device.mac}_" + DOMAIN
         self._attr_supported_features = (
             VacuumEntityFeature.SEND_COMMAND


### PR DESCRIPTION
Migrate integration to has entity name.

https://developers.home-assistant.io/blog/2022/07/10/entity_naming/
https://developers.home-assistant.io/docs/core/entity/#has_entity_name-true-mandatory-for-new-integrations
https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/has-entity-name/
