### PR TITLE
Fix `empty_water_tank` availability

### DIFF
--- a/custom_components/dreame_vacuum/dreame/types.py
+++ b/custom_components/dreame_vacuum/dreame/types.py
@@ -1902,7 +1902,7 @@ ACTION_AVAILABILITY: Final = {
     and not device.status.drying
     and not device.status.auto_emptying,
     "start_recleaning": lambda device: device.status.second_cleaning_available,
-    "empty_water_tank": lambda device: not device.status.water_tank_emptying_available,
+    "empty_water_tank": lambda device: device.status.water_tank_emptying_available,
 }
 
 


### PR DESCRIPTION
After update to v2.0.0.b21 the `empty_water_tank` is always unavailable. This PR fixes that.

Fixes: https://github.com/Tasshack/dreame-vacuum/pull/1224#issuecomment-3633514038