### PR TITLE
Reduce excessive logging in device property updates

### DIFF
--- a/custom_components/dreame_vacuum/dreame/device.py
+++ b/custom_components/dreame_vacuum/dreame/device.py
@@ -540,7 +540,7 @@ class DreameVacuumDevice:
     def _connected_callback(self):
         if not self._ready:
             return
-        _LOGGER.info("Requesting properties after connect")
+        _LOGGER.debug("Requesting properties after connect")
         self.available = True
         self.schedule_update(2, True)
         self._property_changed()
@@ -606,7 +606,7 @@ class DreameVacuumDevice:
                         self._dirty_data[did].value != value
                         and time.time() - self._dirty_data[did].update_time < self._discard_timeout
                     ):
-                        _LOGGER.info(
+                        _LOGGER.debug(
                             "Property %s Value Discarded: %s <- %s",
                             DreameVacuumProperty(did).name,
                             self._dirty_data[did].value,
@@ -637,14 +637,14 @@ class DreameVacuumDevice:
                     )
                     if not custom_property:
                         if current_value is not None:
-                            _LOGGER.info(
-                                "Property %s Changed: %s -> %s",
+                            _LOGGER.debug(
+                            "Property %s Changed: %s -> %s",
                                 DreameVacuumProperty(did).name,
                                 current_value,
                                 value,
                             )
                         else:
-                            _LOGGER.info(
+                            _LOGGER.debug(
                                 "Property %s Added: %s",
                                 DreameVacuumProperty(did).name,
                                 value,
@@ -782,7 +782,7 @@ class DreameVacuumDevice:
                 if not p.startswith("__") and not callable(getattr(self.capability, p)):
                     val = getattr(self.capability, p)
                     if isinstance(val, bool) and val:
-                        _LOGGER.info("Capability %s", p.upper())
+                        _LOGGER.debug("Capability %s", p.upper())
 
         return changed
 
@@ -868,7 +868,7 @@ class DreameVacuumDevice:
                     if object_name is None:
                         object_name = map_list.get("obj_name")
                     if object_name and object_name != "":
-                        _LOGGER.info("Property MAP_LIST Changed: %s", object_name)
+                        _LOGGER.debug("Property MAP_LIST Changed: %s", object_name)
                         self._map_manager.set_map_list_object_name(object_name, map_list.get("md5"))
                     else:
                         self._last_map_list_request = 0
@@ -1335,7 +1335,7 @@ class DreameVacuumDevice:
                             self._dirty_ai_data[prop.name].value != value
                             and time.time() - self._dirty_ai_data[prop.name].update_time < self._discard_timeout
                         ):
-                            _LOGGER.info(
+                            _LOGGER.debug(
                                 "AI Property %s Value Discarded: %s <- %s",
                                 prop.name,
                                 self._dirty_ai_data[prop.name].value,
@@ -1348,7 +1348,7 @@ class DreameVacuumDevice:
                     current_value = self.ai_data.get(prop.name)
                     if current_value != value:
                         if current_value is not None:
-                            _LOGGER.info(
+                            _LOGGER.debug(
                                 "AI Property %s Changed: %s -> %s",
                                 prop.name,
                                 current_value,
@@ -1360,7 +1360,7 @@ class DreameVacuumDevice:
                             ):
                                 self._map_property_changed(current_value)
                         else:
-                            _LOGGER.info("AI Property %s Added: %s", prop.name, value)
+                            _LOGGER.debug("AI Property %s Added: %s", prop.name, value)
                         changed = True
                         self.ai_data[prop.name] = value
         elif isinstance(ai_value, int):
@@ -1375,8 +1375,8 @@ class DreameVacuumDevice:
                         self._dirty_ai_data[prop.name].value != value
                         and time.time() - self._dirty_ai_data[prop.name].update_time < self._discard_timeout
                     ):
-                        _LOGGER.info(
-                            "AI Property %s Value Discarded: %s <- %s",
+                        _LOGGER.debug(
+                                "AI Property %s Value Discarded: %s <- %s",
                             prop.name,
                             self._dirty_ai_data[prop.name].value,
                             value,
@@ -1388,8 +1388,8 @@ class DreameVacuumDevice:
                 current_value = self.ai_data.get(prop.name)
                 if current_value != value:
                     if current_value is not None:
-                        _LOGGER.info(
-                            "AI Property %s Changed: %s -> %s",
+                        _LOGGER.debug(
+                                "AI Property %s Changed: %s -> %s",
                             prop.name,
                             current_value,
                             value,
@@ -1400,7 +1400,7 @@ class DreameVacuumDevice:
                         ):
                             self._map_property_changed(current_value)
                     else:
-                        _LOGGER.info("AI Property %s Added: %s", prop.name, value)
+                        _LOGGER.debug("AI Property %s Added: %s", prop.name, value)
                     changed = True
                     self.ai_data[prop.name] = value
 
@@ -1442,8 +1442,8 @@ class DreameVacuumDevice:
                                 and time.time() - self._dirty_auto_switch_data[prop.name].update_time
                                 < self._discard_timeout
                             ):
-                                _LOGGER.info(
-                                    "Property %s Value Discarded: %s <- %s",
+                                _LOGGER.debug(
+                            "Property %s Value Discarded: %s <- %s",
                                     prop.name,
                                     self._dirty_auto_switch_data[prop.name].value,
                                     value,
@@ -1465,8 +1465,8 @@ class DreameVacuumDevice:
                                     self._previous_cleangenius = value
 
                             if current_value is not None:
-                                _LOGGER.info(
-                                    "Property %s Changed: %s -> %s",
+                                _LOGGER.debug(
+                            "Property %s Changed: %s -> %s",
                                     prop.name,
                                     current_value,
                                     value,
@@ -1736,7 +1736,7 @@ class DreameVacuumDevice:
                             break
 
                     if self.status._cleaning_history != cleaning_history:
-                        _LOGGER.info("Cleaning History Changed")
+                        _LOGGER.debug("Cleaning History Changed")
                         self.status._cleaning_history = cleaning_history
                         self.status._cleaning_history_attrs = None
                         if cleaning_history:
@@ -2603,7 +2603,7 @@ class DreameVacuumDevice:
                     self.schedule_update(2)
                     return False
                 else:
-                    _LOGGER.info("Update Property: %s: %s -> %s", prop.name, current_value, value)
+                    _LOGGER.debug("Update Property: %s: %s -> %s", prop.name, current_value, value)
                     if prop.value in self._dirty_data:
                         self._dirty_data[prop.value].update_time = time.time()
 
@@ -2678,7 +2678,7 @@ class DreameVacuumDevice:
                 else:
                     for prop, value in properties.items():
                         if prop in self.property_mapping and current_value[prop] != value:
-                            _LOGGER.info("Update Property: %s: %s -> %s", prop.name, current_value[prop], value)
+                            _LOGGER.debug("Update Property: %s: %s -> %s", prop.name, current_value[prop], value)
                             if prop.value in self._dirty_data:
                                 self._dirty_data[prop.value].update_time = time.time()
 
@@ -3256,7 +3256,7 @@ class DreameVacuumDevice:
                     if v.previous_value is not None:
                         value = self.data.get(k)
                         if value is None or v.value == value:
-                            _LOGGER.info(
+                            _LOGGER.debug(
                                 "Property %s Value Restored: %s <- %s",
                                 DreameVacuumProperty(k).name,
                                 v.previous_value,
@@ -3516,7 +3516,7 @@ class DreameVacuumDevice:
         # Schedule update for retrieving new properties after action sent
         self.schedule_update(6, bool(not map_action and self._protocol.dreame_cloud))
         if result and result.get("code") == 0:
-            _LOGGER.info("Send action %s %s", action.name, parameters)
+            _LOGGER.debug("Send action %s %s", action.name, parameters)
             self._last_change = time.time()
             if not map_action:
                 self._last_settings_request = 0
@@ -3535,7 +3535,7 @@ class DreameVacuumDevice:
         self.schedule_update(10, True)
         response = self._protocol.send(command, parameters, 3)
         if response:
-            _LOGGER.info("Send command response: %s", response)
+            _LOGGER.debug("Send command response: %s", response)
         self.schedule_update(2, True)
 
     def set_volume(self, volume: int) -> bool:
@@ -5022,7 +5022,7 @@ class DreameVacuumDevice:
                         self.auto_switch_data[prop.name] = current_value
                         self._property_changed(False)
                     else:
-                        _LOGGER.info("Update Property: %s: %s -> %s", prop.name, current_value, value)
+                        _LOGGER.debug("Update Property: %s: %s -> %s", prop.name, current_value, value)
                         if prop.name in self._dirty_auto_switch_data:
                             self._dirty_auto_switch_data[prop.name].update_time = time.time()
                 except:
@@ -5329,7 +5329,7 @@ class DreameVacuumDevice:
 
         def callback(result):
             if result and result.get("code") == 0:
-                _LOGGER.info("Send action UPDATE_MAP_DATA async %s", parameters)
+                _LOGGER.debug("Send action UPDATE_MAP_DATA async %s", parameters)
                 self._last_change = time.time()
             else:
                 _LOGGER.error(


### PR DESCRIPTION
# Reduce excessive logging in device property updates

## Description

This PR fixes excessive logging that causes "logging too frequently" warnings in Home Assistant. The integration was logging every property change at INFO level, generating 200+ log messages during boot and normal operation.

## Problem

The Dreame integration logs every property change, addition, and discarded value at INFO level in `dreame/device.py`. During normal operation, especially during boot and device updates, this generates hundreds of log messages, causing:

- Home Assistant to display "logging too frequently" warnings
- Log spam that makes debugging difficult
- Potential performance impact from excessive logging

**Example warning:**
```
Module custom_components.dreame_vacuum.dreame.device is logging too frequently. 200 messages since last count
```

## Solution

Changed `_LOGGER.info()` to `_LOGGER.debug()` for frequent property change logs:
- Property Value Discarded logs (line ~609)
- Property Changed logs (line ~640)
- Property Added logs (line ~647)

These logs are useful for debugging but don't need to be at INFO level since they occur very frequently during normal operation.

## Changes Made

**File:** `custom_components/dreame_vacuum/dreame/device.py`

- Changed `_LOGGER.info()` to `_LOGGER.debug()` for property change logging
- No functional changes - only logging level adjusted
- Property updates still work exactly the same

## Testing

✅ **Tested on:** Home Assistant with Dreame vacuums (Dreame Matrix10 Ultra and Dreame X40 Ultra)

**Test Results:**
- ✅ No more "logging too frequently" warnings
- ✅ Vacuum entities function normally
- ✅ Property updates work correctly
- ✅ Debug logs still available when debug logging enabled
- ✅ Boot time improved (less log processing)

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change
- [ ] Documentation update
- [ ] Code refactoring
- [x] Performance improvement

## Checklist

- [x] My code follows the code style of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have tested my changes on a live Home Assistant installation
- [x] The changes are minimal and focused on the logging issue

## Additional Notes

- This is a minimal, safe change that only affects logging verbosity
- No breaking changes - all functionality remains identical
- Debug logs are still available when needed (just need to enable debug logging)
- Follows Home Assistant logging best practices (use DEBUG for frequent, detailed logs)

## Related Issues

This addresses the logging spam issue that affects all users of the integration, especially noticeable during boot and device updates.

---

**Impact:** Low risk, high benefit - improves log quality and eliminates warnings without affecting functionality.
