### PR TITLE
Correct units of measurement

### DIFF
--- a/custom_components/dreame_vacuum/const.py
+++ b/custom_components/dreame_vacuum/const.py
@@ -5,9 +5,9 @@ DOMAIN = "dreame_vacuum"
 LOGGER = logging.getLogger(__package__)
 
 UNIT_MINUTES: Final = "min"
-UNIT_HOURS: Final = "hr"
+UNIT_HOURS: Final = "h"
 UNIT_PERCENT: Final = "%"
-UNIT_DAYS: Final = "dy"
+UNIT_DAYS: Final = "d"
 UNIT_AREA: Final = "m²"
 UNIT_TIMES: Final = "x"
 


### PR DESCRIPTION
In Home Assistant, the correct units for days and hours are d and h.