### PR TITLE
Clarify account country options

### DIFF
--- a/custom_components/dreame_vacuum/config_flow.py
+++ b/custom_components/dreame_vacuum/config_flow.py
@@ -714,13 +714,11 @@ class DreameVacuumFlowHandler(ConfigFlow, domain=DOMAIN):
                 }
             )
 
-        country_list = ["eu", "cn", "us", "ru", "sg"]
-        if self.account_type == ACCOUNT_TYPE_MOVA:
-            country_list.pop(3)
-        elif self.account_type == ACCOUNT_TYPE_TROUVER:
-            country_list.pop(1)
-        elif self.account_type == ACCOUNT_TYPE_DREAME:
-            country_list.append("kr")
+        country_list = {
+            ACCOUNT_TYPE_DREAME: ["eu", "cn", "us", "ru", "sg", "kr"],
+            ACCOUNT_TYPE_MOVA: ["eu", "cn", "us", "sg"],
+            ACCOUNT_TYPE_TROUVER: ["eu", "us", "ru", "sg"],
+        }[self.account_type]
 
         return vol.Schema(
             {


### PR DESCRIPTION
## Summary
- Replace index-based country list mutation with explicit account-specific country lists
- Keep MOVA US support visible in the config flow options
- Preserve existing Dreame, MOVA, and Trouver country behavior from dev

## Testing
- python3 -m py_compile custom_components/dreame_vacuum/config_flow.py

## Context
While setting up a MOVA P10 Pro Ultra in Home Assistant, v2.0.0b21 did not expose the US region for MOVA accounts. dev already corrected the behavior, and this cleanup makes the intended region sets explicit so the same regression is less likely to return.