### PR TITLE
fix(i18n): rewrite zh-Hant.json with proper Traditional Chinese (Taiwan)

### DIFF
--- a/custom_components/dreame_vacuum/translations/zh-Hant.json
+++ b/custom_components/dreame_vacuum/translations/zh-Hant.json
@@ -1,48 +1,48 @@
 {
   "config": {
     "abort": {
-      "already_configured": "设备已配置",
-      "cannot_connect": "连接失败",
-      "reauth_successful": "重新认证成功"
+      "already_configured": "裝置已設定",
+      "cannot_connect": "連線失敗",
+      "reauth_successful": "重新驗證成功"
     },
     "error": {
-      "cannot_connect": "连接失败",
-      "unsupported": "此设备尚未支持",
-      "wrong_token": "校验错误，Token无效",
-      "2fa_failed": "需要双重认证登录",
-      "wrong_captcha": "验证码错误",
-      "credentials_incomplete": "认证信息不完整，请填写用户名、密码及国家或地区",
-      "login_error": "登录失败，请检查凭证信息是否有误",
-      "no_devices": "此账号选择的国家或地区的中未找到支持的设备{devices}"
+      "cannot_connect": "連線失敗",
+      "unsupported": "此裝置尚未支援",
+      "wrong_token": "驗證錯誤，Token 無效",
+      "2fa_failed": "需要雙重驗證登入",
+      "wrong_captcha": "驗證碼錯誤",
+      "credentials_incomplete": "驗證資訊不完整，請填寫使用者名稱、密碼及國家或地區",
+      "login_error": "登入失敗，請確認憑證資訊是否有誤",
+      "no_devices": "此帳號所選國家或地區中未找到支援的裝置{devices}"
     },
     "step": {
       "user": {
         "data": {
-          "configuration_type": "配置类型"
+          "configuration_type": "設定類型"
         },
-        "description": "地图功能需连接云端，并提供自动配置。若无需使用地图功能，可选择手动配置。"
+        "description": "地圖功能需連接雲端，並提供自動設定。若無需使用地圖功能，可選擇手動設定。"
       },
       "local": {
         "data": {
           "host": "Host",
           "token": "Token"
         },
-        "description": "需要提供32位API Token"
+        "description": "需要提供 32 位元 API Token"
       },
       "mi": {
         "data": {
-          "username": "用户名",
-          "password": "密码",
-          "country": "服务器所在区域",
-          "prefer_cloud": "使用云端连接"
+          "username": "使用者名稱",
+          "password": "密碼",
+          "country": "伺服器所在區域",
+          "prefer_cloud": "使用雲端連線"
         },
-        "description": "请登录小米米家云服务"
+        "description": "請登入小米米家雲端服務"
       },
       "2fa": {
         "data": {
-          "verification_code": "双因素验证码"
+          "verification_code": "雙重要素驗證碼"
         },
-        "description": "## 本次登录需安全验证\n请打开验证页面获取手机/邮箱验证码。收到验证码后，请勿在网页端验证，返回 HomeAssistant 并在下方输入框中输入验证码。\n### [发送验证码]({url})"
+        "description": "## 本次登入需安全驗證\n請開啟驗證頁面取得手機／電子郵件驗證碼。收到驗證碼後，請勿在網頁端驗證，返回 HomeAssistant 並在下方輸入框中輸入驗證碼。\n### [傳送驗證碼]({url})"
       },
       "captcha": {
         "data": {
@@ -52,54 +52,54 @@
       },
       "dreame": {
         "data": {
-          "username": "用户名",
-          "password": "密码",
-          "country": "服务器所在区域"
+          "username": "使用者名稱",
+          "password": "密碼",
+          "country": "伺服器所在區域"
         },
-        "description": "登录追觅账号"
+        "description": "登入追覓帳號"
       },
       "mova": {
         "data": {
-          "username": "用户名",
-          "password": "密码",
-          "country": "服务器所在区域"
+          "username": "使用者名稱",
+          "password": "密碼",
+          "country": "伺服器所在區域"
         },
-        "description": "登录Mova账号"
+        "description": "登入 Mova 帳號"
       },
       "trouver": {
         "data": {
-          "username": "用户名",
-          "password": "密码",
-          "country": "服务器所在区域"
+          "username": "使用者名稱",
+          "password": "密碼",
+          "country": "伺服器所在區域"
         },
-        "description": "登录Trouver账号"
+        "description": "登入 Trouver 帳號"
       },
       "devices": {
         "data": {
-          "devices": "支持的设备"
+          "devices": "支援的裝置"
         },
-        "description": "请选择需要设置的追觅扫地机器人设备"
+        "description": "請選擇要設定的追覓掃地機器人裝置"
       },
       "donation": {
         "data": {
-          "donated": "已捐赠"
+          "donated": "已捐贈"
         },
-        "description": "## 不要忘记支持该项目。{text}"
+        "description": "## 別忘了支持本專案。{text}"
       },
       "options": {
         "data": {
-          "name": "名称",
-          "color_scheme": "地图配色方案",
-          "icon_set": "图标风格",
+          "name": "名稱",
+          "color_scheme": "地圖配色方案",
+          "icon_set": "圖示風格",
           "notify": "通知",
           "hidden_map_objects": "隱藏的地圖物件",
-          "low_resolution": "低分辨率地图",
-          "square": "方形地图"
+          "low_resolution": "低解析度地圖",
+          "square": "方形地圖"
         }
       },
       "reauth_confirm": {
-        "description": "追觅扫地机器人需要重新登录您的账户，用于更新访问令牌或补填云服务账号信息",
-        "title": "重新授权"
+        "description": "追覓掃地機器人需要重新登入您的帳戶，用於更新存取權杖或補充雲端服務帳號資訊",
+        "title": "重新授權"
       }
     }
   },
@@ -107,36 +107,36 @@
     "step": {
       "init": {
         "data": {
-          "color_scheme": "地图配色方案",
-          "icon_set": "图标风格",
+          "color_scheme": "地圖配色方案",
+          "icon_set": "圖示風格",
           "notify": "通知",
           "hidden_map_objects": "隱藏的地圖物件",
-          "low_resolution": "低分辨率地图",
-          "square": "方形地图",
-          "configuration_type": "配置方式",
-          "prefer_cloud": "使用云端连接",
-          "donated": "已捐赠"
+          "low_resolution": "低解析度地圖",
+          "square": "方形地圖",
+          "configuration_type": "設定方式",
+          "prefer_cloud": "使用雲端連線",
+          "donated": "已捐贈"
         }
       }
     },
     "error": {
-      "cloud_credentials_incomplete": "云端服务凭证不完整，请填写用户名、密码及国家或地区"
+      "cloud_credentials_incomplete": "雲端服務憑證不完整，請填寫使用者名稱、密碼及國家或地區"
     }
   },
   "entity": {
     "select": {
       "suction_level": {
-        "name": "吸力力度",
+        "name": "吸力強度",
         "state": {
-          "quiet": "安静",
-          "standard": "标准",
-          "strong": "强力",
-          "turbo": "超强",
+          "quiet": "安靜",
+          "standard": "標準",
+          "strong": "強力",
+          "turbo": "超強",
           "full_power": "全功率"
         }
       },
       "water_volume": {
-        "name": "出水速度",
+        "name": "出水量",
         "state": {
           "low": "低",
           "medium": "中",
@@ -146,18 +146,18 @@
       "mop_pad_humidity": {
         "name": "拖布濕度",
         "state": {
-          "slightly_dry": "稍干",
-          "moist": "湿润",
-          "wet": "潮湿"
+          "slightly_dry": "微乾",
+          "moist": "濕潤",
+          "wet": "潮濕"
         }
       },
       "cleaning_mode": {
         "name": "清潔模式",
         "state": {
-          "sweeping": "仅扫地",
-          "mopping": "仅拖地",
-          "sweeping_and_mopping": "同时扫拖",
-          "mopping_after_sweeping": "先扫后拖"
+          "sweeping": "僅掃地",
+          "mopping": "僅拖地",
+          "sweeping_and_mopping": "同時掃拖",
+          "mopping_after_sweeping": "先掃後拖"
         }
       },
       "carpet_sensitivity": {
@@ -171,11 +171,11 @@
       "carpet_cleaning": {
         "name": "地毯清潔策略",
         "state": {
-          "avoidance": "避开地毯",
-          "adaptation": "自适应",
+          "avoidance": "避開地毯",
+          "adaptation": "自適應",
           "remove_mop": "升起拖布",
-          "adaptation_without_route": "无路径自适应",
-          "vacuum_and_mop": "扫拖同步",
+          "adaptation_without_route": "無路徑自適應",
+          "vacuum_and_mop": "掃拖同步",
           "ignore": "忽略地毯",
           "cross": "穿越"
         }
@@ -183,7 +183,7 @@
       "mop_wash_level": {
         "name": "拖布清洗模式",
         "state": {
-          "water_saving": "节水",
+          "water_saving": "節水",
           "daily": "日常",
           "deep": "深度",
           "ultra_clean_mode": "超級潔淨"
@@ -192,7 +192,7 @@
       "mopping_type": {
         "name": "拖地類型",
         "state": {
-          "accurate": "精准",
+          "accurate": "精準",
           "daily": "日常",
           "deep": "深度"
         }
@@ -200,33 +200,33 @@
       "wider_corner_coverage": {
         "name": "邊角覆蓋增強",
         "state": {
-          "off": "关闭",
-          "high_frequency": "高频率",
-          "low_frequency": "低频率"
+          "off": "關閉",
+          "high_frequency": "高頻率",
+          "low_frequency": "低頻率"
         }
       },
       "mop_pad_swing": {
         "name": "扭扭擦",
         "state": {
-          "off": "关闭",
-          "auto": "自动",
+          "off": "關閉",
+          "auto": "自動",
           "daily": "每日",
-          "weekly": "每周"
+          "weekly": "每週"
         }
       },
       "mop_extend_frequency": {
         "name": "仿生外擴頻率",
         "state": {
-          "standard": "标准",
-          "intelligent": "智能",
-          "high": "频繁"
+          "standard": "標準",
+          "intelligent": "智慧",
+          "high": "頻繁"
         }
       },
       "floor_material": {
         "name": "地面材質",
         "state": {
-          "none": "未设置",
-          "tile": "瓷砖",
+          "none": "未設定",
+          "tile": "瓷磚",
           "wood": "木地板",
           "low_pile_carpet": "短毛地毯",
           "medium_pile_carpet": "中長毛地毯",
@@ -286,22 +286,22 @@
       "order": {
         "name": "排序",
         "state": {
-          "not_set": "未设置"
+          "not_set": "未設定"
         }
       },
       "self_clean_frequency": {
         "name": "自動洗布頻率",
         "state": {
-          "by_area": "按面积",
-          "by_time": "按时间",
-          "by_room": "按房间",
-          "intelligent": "智能"
+          "by_area": "依面積",
+          "by_time": "依時間",
+          "by_room": "依房間",
+          "intelligent": "智慧"
         }
       },
       "mop_clean_frequency": {
         "name": "洗布頻率",
         "state": {
-          "by_room": "按房間",
+          "by_room": "依房間",
           "5sqm": "五平方米",
           "8sqm": "八平方米",
           "10sqm": "十平方米",
@@ -319,94 +319,94 @@
       "auto_empty_mode": {
         "name": "自動集塵模式",
         "state": {
-          "off": "关闭",
-          "standard": "标准",
-          "high_frequency": "高频率",
-          "low_frequency": "低频率",
+          "off": "關閉",
+          "standard": "標準",
+          "high_frequency": "高頻率",
+          "low_frequency": "低頻率",
           "custom_frequency": "自訂頻率",
-          "intelligent": "智能"
+          "intelligent": "智慧"
         }
       },
       "floor_material_direction": {
         "name": "地板方向",
         "state": {
-          "vertical": "纵向",
-          "horizontal": "横向"
+          "vertical": "縱向",
+          "horizontal": "橫向"
         }
       },
       "visibility": {
         "name": "顯示狀態",
         "state": {
-          "visible": "显示",
-          "hidden": "隐藏"
+          "visible": "顯示",
+          "hidden": "隱藏"
         }
       },
       "cleangenius": {
         "name": "CleanGenius",
         "state": {
-          "off": "关闭",
-          "routine_cleaning": "日常清洁",
-          "deep_cleaning": "深度清洁"
+          "off": "關閉",
+          "routine_cleaning": "日常清潔",
+          "deep_cleaning": "深度清潔"
         }
       },
       "cleangenius_mode": {
         "name": "CleanGenius 模式",
         "state": {
-          "vacuum_and_mop": "扫拖同步",
-          "mop_after_vacuum": "先扫后拖"
+          "vacuum_and_mop": "掃拖同步",
+          "mop_after_vacuum": "先掃後拖"
         }
       },
       "washing_mode": {
         "name": "清洗模式",
         "state": {
-          "smart": "智能",
-          "light": "轻度",
-          "standard": "标准",
+          "smart": "智慧",
+          "light": "輕度",
+          "standard": "標準",
           "deep": "深度",
-          "ultra_washing": "强力清洗"
+          "ultra_washing": "強力清洗"
         }
       },
       "water_temperature": {
         "name": "清洗水溫",
         "state": {
-          "normal": "常温",
-          "mild": "微温",
-          "warm": "温",
-          "hot": "热",
+          "normal": "常溫",
+          "mild": "微溫",
+          "warm": "溫熱",
+          "hot": "熱",
           "max": "最高"
         }
       },
       "auto_recleaning": {
         "name": "自動二次清掃",
         "state": {
-          "off": "关闭",
-          "in_deep_mode": "深度模式下",
-          "in_all_modes": "所有模式下"
+          "off": "關閉",
+          "in_deep_mode": "深度模式中",
+          "in_all_modes": "所有模式中"
         }
       },
       "auto_rewashing": {
         "name": "自動二次洗布",
         "state": {
-          "off": "关闭",
-          "in_deep_mode": "深度模式下",
-          "in_all_modes": "所有模式下"
+          "off": "關閉",
+          "in_deep_mode": "深度模式中",
+          "in_all_modes": "所有模式中"
         }
       },
       "cleaning_route": {
         "name": "清掃路徑",
         "state": {
           "quick": "快速",
-          "standard": "标准",
-          "intensive": "精细",
+          "standard": "標準",
+          "intensive": "精細",
           "deep": "深度"
         }
       },
       "custom_mopping_route": {
         "name": "定制拖地路徑",
         "state": {
-          "off": "关闭",
-          "standard": "标准",
-          "intensive": "精细",
+          "off": "關閉",
+          "standard": "標準",
+          "intensive": "精細",
           "deep": "深度"
         }
       },
@@ -431,13 +431,13 @@
       "auto_empty_frequency": {
         "name": "自動集塵頻率",
         "state": {
-          "x1": "任務完成后",
-          "x2": "清掃2次后",
-          "x3": "清掃3次后"
+          "x1": "任務完成後",
+          "x2": "清掃 2 次後",
+          "x3": "清掃 3 次後"
         }
       },
       "drying_time": {
-        "name": "烘干時間",
+        "name": "烘乾時間",
         "state": {
           "silent": "靜音"
         }
@@ -450,7 +450,7 @@
         "state": {
           "predefined_point": "預設點",
           "low_lying_area": "低矮區域",
-          "curtain": "窗帘",
+          "curtain": "窗簾",
           "threshold": "門檻",
           "furniture": "家具",
           "carpet": "地毯",
@@ -461,7 +461,7 @@
         "name": "編輯類型",
         "state": {
           "split": "分割房間",
-          "merge": "合并房間",
+          "merge": "合併房間",
           "visibility": "房間可見性",
           "material": "地面材質",
           "type": "房間名稱"
@@ -472,7 +472,7 @@
         "state": {
           "cleaning": "清掃地圖",
           "history": "清掃詳情",
-          "wifi": "Wi-Fi地圖"
+          "wifi": "Wi-Fi 地圖"
         }
       },
       "carpet_type": {
@@ -509,18 +509,18 @@
       "wetness_level": {
         "name": "濕度",
         "state": {
-          "slightly_dry": "微干",
+          "slightly_dry": "微乾",
           "moist": "濕潤",
           "wet": "潮濕"
         }
       },
       "task_repeats": {
-        "name": "任務重复",
+        "name": "任務重複",
         "state": {
           "once": "一次",
           "daily": "每天",
           "workdays": "工作日",
-          "weekends": "周末"
+          "weekends": "週末"
         }
       },
       "segment_name": {
@@ -532,7 +532,7 @@
           "study": "書房",
           "kitchen": "廚房",
           "dining_hall": "餐廳",
-          "bathroom": "衛生間",
+          "bathroom": "浴室",
           "balcony": "陽台",
           "corridor": "走廊",
           "utility_room": "雜物間",
@@ -540,7 +540,7 @@
           "meeting_room": "會議室",
           "office": "辦公室",
           "fitness_area": "健身區",
-          "recreation_area": "休閑區",
+          "recreation_area": "休閒區",
           "secondary_bedroom": "次臥"
         }
       },
@@ -553,7 +553,7 @@
           "two_seat_sofa": "雙人沙發",
           "three_seat_sofa": "三人沙發",
           "dining_table": "餐桌",
-          "nightstant": "床頭柜",
+          "nightstant": "床頭櫃",
           "coffee_table": "茶几",
           "toilet": "馬桶",
           "litter_box": "貓砂盆",
@@ -561,62 +561,62 @@
           "food_bowl": "食盆",
           "pet_toilet": "寵物廁所",
           "refrigerator": "冰箱",
-          "washing_machine": "洗衣机",
+          "washing_machine": "洗衣機",
           "enclosed_litter_box": "封閉式貓砂盆",
           "air_conditioner": "空調",
-          "tv_cabinet": "電視柜",
+          "tv_cabinet": "電視櫃",
           "bookshelf": "書架",
-          "shoe_cabinet": "鞋柜",
-          "wardrobe": "衣柜",
+          "shoe_cabinet": "鞋櫃",
+          "wardrobe": "衣櫃",
           "greenery": "綠植",
           "floor_mirror": "穿衣鏡",
-          "l_shaped_sofa": "L型沙發",
+          "l_shaped_sofa": "L 型沙發",
           "round_coffee_table": "圓茶几",
           "table": "桌子",
           "arm_chair_narrow": "窄扶手椅",
           "three_seat_sofa_narrow": "窄三人沙發",
-          "l_shaped_sofa_right": "右側L型沙發"
+          "l_shaped_sofa_right": "右側 L 型沙發"
         }
       }
     },
     "sensor": {
       "state": {
-        "name": "當前狀態",
+        "name": "目前狀態",
         "state": {
           "unknown": "未知",
-          "sweeping": "清扫中",
-          "charging": "充电中",
-          "error": "错误",
-          "idle": "待机",
-          "paused": "暂停",
+          "sweeping": "清掃中",
+          "charging": "充電中",
+          "error": "錯誤",
+          "idle": "待機",
+          "paused": "已暫停",
           "returning": "返回基座",
           "mopping": "拖地中",
-          "drying": "烘干中",
+          "drying": "烘乾中",
           "washing": "清洗中",
           "returning_to_wash": "返回清洗",
-          "building": "建图中",
-          "sweeping_and_mopping": "扫拖同步",
-          "charging_completed": "充电完成",
-          "upgrading": "升级中",
-          "clean_summon": "召唤清洁",
+          "building": "建圖中",
+          "sweeping_and_mopping": "掃拖同步",
+          "charging_completed": "充電完成",
+          "upgrading": "升級中",
+          "clean_summon": "召喚清潔",
           "station_reset": "基站重置",
-          "returning_install_mop": "返回安装拖布",
+          "returning_install_mop": "返回安裝拖布",
           "returning_remove_mop": "返回拆卸拖布",
-          "water_check": "水量检测中",
-          "clean_add_water": "清洁并加水",
-          "washing_paused": "暂停清洗",
-          "auto_emptying": "自动集尘中",
-          "remote_control": "遥控中",
-          "smart_charging": "智能充电",
-          "second_cleaning": "二次清洁",
-          "human_following": "人员跟随",
-          "spot_cleaning": "局部清洁",
-          "returning_auto_empty": "返回自动集尘",
-          "waiting_for_task": "等待任务",
-          "station_cleaning": "基站自清洁中",
+          "water_check": "水量偵測中",
+          "clean_add_water": "清潔並加水",
+          "washing_paused": "暫停清洗",
+          "auto_emptying": "自動集塵中",
+          "remote_control": "遙控中",
+          "smart_charging": "智慧充電",
+          "second_cleaning": "二次清潔",
+          "human_following": "人員跟隨",
+          "spot_cleaning": "局部清潔",
+          "returning_auto_empty": "返回自動集塵",
+          "waiting_for_task": "等待任務",
+          "station_cleaning": "基站自清潔中",
           "returning_to_drain": "返回排水中",
           "draining": "排水中",
-          "auto_water_draining": "自动排水中",
+          "auto_water_draining": "自動排水中",
           "emptying": "正在清空",
           "dust_bag_drying": "塵袋乾燥",
           "dust_bag_drying_paused": "塵袋乾燥已暫停",
@@ -625,8 +625,8 @@
           "finding_pet_paused": "正在尋找寵物已暫停",
           "finding_pet": "正在尋找寵物",
           "shortcut": "快捷指令",
-          "monitoring": "监控中",
-          "monitoring_paused": "监控暂停",
+          "monitoring": "監控中",
+          "monitoring_paused": "監控暫停",
           "initial_deep_cleaning": "初始深度清潔",
           "initial_deep_cleaning_paused": "初始深度清潔已暫停",
           "sanitizing": "正在消毒",
@@ -641,78 +641,78 @@
         "name": "運行狀態",
         "state": {
           "unknown": "未知",
-          "idle": "待机",
-          "paused": "暂停",
-          "cleaning": "清洁中",
+          "idle": "待機",
+          "paused": "已暫停",
+          "cleaning": "清潔中",
           "returning": "返回基座",
-          "spot_cleaning": "局部清洁",
-          "follow_wall_cleaning": "沿墙清洁",
-          "charging": "充电中",
-          "ota": "固件升级",
-          "fct": "工厂模式",
-          "wifi_set": "WiFi设置",
-          "power_off": "已关机",
-          "factory": "恢复出厂",
-          "error": "错误",
-          "remote_control": "遥控模式",
+          "spot_cleaning": "局部清潔",
+          "follow_wall_cleaning": "沿牆清潔",
+          "charging": "充電中",
+          "ota": "韌體升級",
+          "fct": "出廠模式",
+          "wifi_set": "WiFi 設定",
+          "power_off": "已關機",
+          "factory": "恢復出廠設定",
+          "error": "錯誤",
+          "remote_control": "遙控模式",
           "sleeping": "休眠中",
           "self_test": "自檢中",
-          "factory_test": "工厂测试",
-          "standby": "就绪",
-          "room_cleaning": "房间清洁",
-          "zone_cleaning": "区域清洁",
-          "fast_mapping": "快速建图",
-          "cruising_path": "路径巡航",
-          "cruising_point": "定点巡航",
-          "summon_clean": "召唤清洁",
+          "factory_test": "出廠測試",
+          "standby": "就緒",
+          "room_cleaning": "房間清潔",
+          "zone_cleaning": "區域清潔",
+          "fast_mapping": "快速建圖",
+          "cruising_path": "路徑巡航",
+          "cruising_point": "定點巡航",
+          "summon_clean": "召喚清潔",
           "shortcut": "快捷指令",
-          "person_follow": "人员跟随",
-          "water_check": "水量检测"
+          "person_follow": "人員跟隨",
+          "water_check": "水量偵測"
         }
       },
       "task_status": {
         "name": "任務狀態",
         "state": {
           "unknown": "未知",
-          "completed": "完成",
-          "cleaning": "清洁中",
-          "zone_cleaning": "区域清洁中",
-          "room_cleaning": "房间清洁中",
-          "spot_cleaning": "定点清洁中",
-          "fast_mapping": "快速建图中",
-          "cleaning_paused": "清洁已暂停",
-          "room_cleaning_paused": "房间清洁已暂停",
-          "zone_cleaning_paused": "区域清洁已暂停",
-          "spot_cleaning_paused": "定点清洁已暂停",
-          "map_cleaning_paused": "地图清洁已暂停",
-          "docking_paused": "回充已暂停",
-          "mopping_paused": "拖地已暂停",
-          "zone_mopping_paused": "区域拖地已暂停",
-          "room_mopping_paused": "房间拖地已暂停",
-          "zone_docking_paused": "区域回充已暂停",
-          "room_docking_paused": "房间回充已暂停",
-          "cruising_path": "路径巡航中",
-          "cruising_path_paused": "路径巡航已暂停",
-          "cruising_point": "定点巡航中",
-          "cruising_point_paused": "定点巡航已暂停",
-          "summon_clean_paused": "召唤清洁已暂停",
-          "returning_to_install_mop": "返回安装拖布中",
+          "completed": "已完成",
+          "cleaning": "清潔中",
+          "zone_cleaning": "區域清潔中",
+          "room_cleaning": "房間清潔中",
+          "spot_cleaning": "定點清潔中",
+          "fast_mapping": "快速建圖中",
+          "cleaning_paused": "清潔已暫停",
+          "room_cleaning_paused": "房間清潔已暫停",
+          "zone_cleaning_paused": "區域清潔已暫停",
+          "spot_cleaning_paused": "定點清潔已暫停",
+          "map_cleaning_paused": "地圖清潔已暫停",
+          "docking_paused": "回充已暫停",
+          "mopping_paused": "拖地已暫停",
+          "zone_mopping_paused": "區域拖地已暫停",
+          "room_mopping_paused": "房間拖地已暫停",
+          "zone_docking_paused": "區域回充已暫停",
+          "room_docking_paused": "房間回充已暫停",
+          "cruising_path": "路徑巡航中",
+          "cruising_path_paused": "路徑巡航已暫停",
+          "cruising_point": "定點巡航中",
+          "cruising_point_paused": "定點巡航已暫停",
+          "summon_clean_paused": "召喚清潔已暫停",
+          "returning_to_install_mop": "返回安裝拖布中",
           "returning_to_remove_mop": "返回拆卸拖布中",
-          "station_cleaning": "基站自清洁中",
-          "pet_finding": "寻宠中",
-          "auto_cleaning_washing_paused": "自动洗拖暂停",
-          "area_cleaning_washing_paused": "区域洗拖暂停",
-          "custom_cleaning_washing_paused": "定制洗拖暂停"
+          "station_cleaning": "基站自清潔中",
+          "pet_finding": "尋寵中",
+          "auto_cleaning_washing_paused": "自動洗拖暫停",
+          "area_cleaning_washing_paused": "區域洗拖暫停",
+          "custom_cleaning_washing_paused": "定制洗拖暫停"
         }
       },
       "water_tank": {
         "name": "水箱",
         "state": {
           "unknown": "未知",
-          "installed": "已安装",
-          "not_installed": "未安装",
-          "mop_installed": "拖布已安装",
-          "in_station": "在基站内"
+          "installed": "已安裝",
+          "not_installed": "未安裝",
+          "mop_installed": "拖布已安裝",
+          "in_station": "在基站內"
         }
       },
       "mop_pad": {
@@ -739,76 +739,76 @@
         "name": "自動集塵狀態",
         "state": {
           "unknown": "未知",
-          "idle": "待机",
-          "active": "运行中",
-          "not_performed": "未执行"
+          "idle": "待機",
+          "active": "運行中",
+          "not_performed": "未執行"
         }
       },
       "error": {
         "name": "故障",
         "state": {
-          "unknown": "未知错误",
-          "no_error": "运行正常",
-          "drop": "轮子悬空",
-          "cliff": "悬崖传感器异常",
-          "bumper": "碰撞传感器卡住",
-          "gesture": "设备倾斜",
-          "bumper_repeat": "碰撞传感器持续卡住",
-          "drop_repeat": "轮子持续悬空",
-          "optical_flow": "光学流量传感器异常",
-          "no_box": "尘盒未安装",
-          "no_tank_box": "水箱未安装",
+          "unknown": "未知錯誤",
+          "no_error": "運行正常",
+          "drop": "輪子懸空",
+          "cliff": "懸崖感應器異常",
+          "bumper": "碰撞感應器卡住",
+          "gesture": "裝置傾斜",
+          "bumper_repeat": "碰撞感應器持續卡住",
+          "drop_repeat": "輪子持續懸空",
+          "optical_flow": "光學流量感應器異常",
+          "no_box": "塵盒未安裝",
+          "no_tank_box": "水箱未安裝",
           "water_box_empty": "水箱缺水",
-          "box_full": "滤网未干或堵塞",
-          "brush": "主刷缠绕",
-          "side_brush": "边刷缠绕",
-          "fan": "滤网未干或堵塞",
-          "left_wheel_motor": "左轮卡住或异物阻塞",
-          "right_wheel_motor": "右轮卡住或异物阻塞",
-          "turn_suffocate": "转向受阻",
-          "forward_suffocate": "前进受阻",
+          "box_full": "濾網未乾或堵塞",
+          "brush": "主刷纏繞",
+          "side_brush": "邊刷纏繞",
+          "fan": "濾網未乾或堵塞",
+          "left_wheel_motor": "左輪卡住或異物阻塞",
+          "right_wheel_motor": "右輪卡住或異物阻塞",
+          "turn_suffocate": "轉向受阻",
+          "forward_suffocate": "前進受阻",
           "charger_get": "未找到基站",
-          "battery_low": "电量不足",
-          "charge_fault": "充电异常",
-          "battery_percentage": "电量检测异常",
-          "heart": "内部出错",
-          "camera_occlusion": "视觉传感器遮挡",
-          "move": "位移传感器异常",
-          "flow_shielding": "光学传感器异常",
-          "infrared_shielding": "红外传感器异常",
-          "charge_no_electric": "基站未通电",
-          "battery_fault": "电池故障",
-          "fan_speed_error": "风机转速异常",
-          "left_wheell_speed": "左轮转速异常",
-          "right_wheell_speed": "右轮转速异常",
-          "bmi055_acce": "加速度计异常",
-          "bmi055_gyro": "陀螺仪异常",
-          "xv7001": "陀螺仪校准异常",
-          "left_magnet": "左磁传感器异常",
-          "right_magnet": "右磁传感器异常",
-          "flow_error": "流量传感器异常",
-          "infrared_fault": "红外功能异常",
-          "camera_fault": "视觉系统异常",
-          "strong_magnet": "检测到强磁场",
-          "water_pump": "水泵异常",
-          "rtc": "时钟模块异常",
-          "auto_key_trig": "自动触发异常",
-          "p3v3": "电源模块异常",
-          "camera_idle": "视觉系统待机异常",
-          "blocked": "行进路线受阻，正在返回基站",
-          "lds_error": "激光雷达异常",
-          "lds_bumper": "激光防撞系统异常",
-          "filter_blocked": "滤网堵塞",
-          "edge": "沿边传感器异常",
-          "carpet": "请在地毯区域外启动",
-          "laser": "3D避障系统异常",
-          "ultrasonic": "超声波传感器异常",
-          "no_go_zone": "检测到禁行区/虚拟墙",
-          "route": "清扫路线受阻",
-          "restricted": "设备处于限制区域",
-          "remove_mop": "拖地完成，请及时清洗拖布",
-          "mop_removed": "清洁过程中拖布脱落",
-          "mop_pad_stop_rotate": "拖布停止旋转",
+          "battery_low": "電量不足",
+          "charge_fault": "充電異常",
+          "battery_percentage": "電量偵測異常",
+          "heart": "內部出錯",
+          "camera_occlusion": "視覺感應器遮擋",
+          "move": "位移感應器異常",
+          "flow_shielding": "光學感應器異常",
+          "infrared_shielding": "紅外線感應器異常",
+          "charge_no_electric": "基站未通電",
+          "battery_fault": "電池故障",
+          "fan_speed_error": "風機轉速異常",
+          "left_wheell_speed": "左輪轉速異常",
+          "right_wheell_speed": "右輪轉速異常",
+          "bmi055_acce": "加速度計異常",
+          "bmi055_gyro": "陀螺儀異常",
+          "xv7001": "陀螺儀校準異常",
+          "left_magnet": "左磁感應器異常",
+          "right_magnet": "右磁感應器異常",
+          "flow_error": "流量感應器異常",
+          "infrared_fault": "紅外線功能異常",
+          "camera_fault": "視覺系統異常",
+          "strong_magnet": "偵測到強磁場",
+          "water_pump": "水泵異常",
+          "rtc": "時鐘模組異常",
+          "auto_key_trig": "自動觸發異常",
+          "p3v3": "電源模組異常",
+          "camera_idle": "視覺系統待機異常",
+          "blocked": "行進路線受阻，正在返回基站",
+          "lds_error": "雷射雷達異常",
+          "lds_bumper": "雷射防撞系統異常",
+          "filter_blocked": "濾網堵塞",
+          "edge": "沿邊感應器異常",
+          "carpet": "請在地毯區域外啟動",
+          "laser": "3D 避障系統異常",
+          "ultrasonic": "超音波感應器異常",
+          "no_go_zone": "偵測到禁行區／虛擬牆",
+          "route": "清掃路線受阻",
+          "restricted": "裝置處於限制區域",
+          "remove_mop": "拖地完成，請及時清洗拖布",
+          "mop_removed": "清潔過程中拖布脫落",
+          "mop_pad_stop_rotate": "拖布停止旋轉",
           "bin_full": "集塵袋已滿或風道堵塞",
           "bin_open": "集塵倉未關閉或塵袋未安裝",
           "water_tank": "清水箱未安裝",
@@ -832,26 +832,26 @@
           "robot_in_hidden_room": "處於禁止區域，請將機器人移至可運行區域後重試",
           "washboard_not_working": "清洗盤停止工作",
           "return_to_charge_failed": "回充失敗",
-          "lds_failed_to_lift": "LDS模組升降失敗。",
-          "robot_stuck": "此處無法升起LDS進行定位。",
+          "lds_failed_to_lift": "LDS 模組升降失敗。",
+          "robot_stuck": "此處無法升起 LDS 進行定位。",
           "robot_stuck_repeat": "請將機器人移至開闊區域並恢復任務。",
           "slippery_floor": "地面濕滑，請稍後重試。",
           "check_mop_install": "請檢查拖布是否安裝正確。",
-          "dirty_water_tank_full": "汙水箱水位異常。",
+          "dirty_water_tank_full": "污水箱水位異常。",
           "retractable_leg_stuck": "請檢查伸縮腿是否被纏繞。",
           "internal_error": "內部錯誤導致故障，請嘗試重啟機器人。",
           "robot_stuck_on_tables": "機器人卡在桌椅之間。",
           "robot_stuck_on_passage": "機器人卡在狹窄通道中。",
-          "robot_stuck_on_threshold": "機器人卡在台階/門檻上。",
+          "robot_stuck_on_threshold": "機器人卡在台階／門檻上。",
           "robot_stuck_on_low_lying_area": "機器人卡在低矮區域。",
-          "robot_stuck_on_ramp": "機器人檢測到路徑上有危險坡道。",
-          "robot_stuck_on_obstacle": "機器人檢測到路徑上有障礙物。",
-          "robot_stuck_on_pet": "機器人檢測到路徑上有人或寵物。",
+          "robot_stuck_on_ramp": "機器人偵測到路徑上有危險坡道。",
+          "robot_stuck_on_obstacle": "機器人偵測到路徑上有障礙物。",
+          "robot_stuck_on_pet": "機器人偵測到路徑上有人或寵物。",
           "robot_stuck_on_slippery_surface": "機器人因打滑被困。",
           "robot_stuck_on_carpet": "機器人在地毯上打滑",
-          "drainage_failed": "汙水箱排水異常",
-          "mop_not_detected": "未檢測到拖布。",
-          "mop_holder_error": "基站內拖布支架數量/位置錯誤。",
+          "drainage_failed": "污水箱排水異常",
+          "mop_not_detected": "未偵測到拖布。",
+          "mop_holder_error": "基站內拖布支架數量／位置錯誤。",
           "dock_error": "基站錯誤。",
           "wash_failed": "清洗髒拖布失敗。",
           "robot_stuck_on_curtain": "機器人在窗簾區域打滑",
@@ -861,7 +861,7 @@
           "mop_cover_error": "請檢查滾筒拖布和蓋板附近是否有雜物。",
           "roller_mop_error": "請檢查滾筒拖布和蓋板附近是否有雜物。",
           "onboard_water_tank_empty": "主機清水箱水位低。",
-          "onboard_dirty_water_tank_full": "主機汙水箱已滿。",
+          "onboard_dirty_water_tank_full": "主機污水箱已滿。",
           "mop_not_installed": "拖布未安裝。",
           "fluffing_roller_error": "絨毛滾筒錯誤。",
           "blocked_by_obstacle": "機器人被障礙物阻擋。"
@@ -871,10 +871,10 @@
         "name": "充電狀態",
         "state": {
           "unknown": "未知",
-          "charging": "充电中",
-          "not_charging": "未充电",
-          "return_to_charge": "返回充电",
-          "charging_completed": "充电完成"
+          "charging": "充電中",
+          "not_charging": "未充電",
+          "return_to_charge": "返回充電",
+          "charging_completed": "充電完成"
         }
       },
       "relocation_status": {
@@ -883,7 +883,7 @@
           "unknown": "未知",
           "located": "已定位",
           "locating": "定位中",
-          "failed": "失败",
+          "failed": "失敗",
           "success": "成功"
         }
       },
@@ -891,12 +891,12 @@
         "name": "基站清洗狀態",
         "state": {
           "unknown": "未知",
-          "idle": "待机",
+          "idle": "待機",
           "washing": "清洗中",
-          "drying": "烘干中",
-          "paused": "已暂停",
+          "drying": "烘乾中",
+          "paused": "已暫停",
           "returning": "返回清洗中",
-          "clean_add_water": "清洁加水",
+          "clean_add_water": "清潔加水",
           "adding_water": "加水中"
         }
       },
@@ -904,31 +904,31 @@
         "name": "缺水提醒",
         "state": {
           "no_warning": "水量正常",
-          "no_water_left": "清水箱即将耗尽，请及时检查并补充清水",
-          "no_water_left_after_clean": "拖布已清洁，检测到清水不足，请补充清水并清空污水箱",
-          "no_water_for_clean": "清水箱水位过低，已切换至仅吸尘模式",
-          "low_water": "清水即将用尽，请及时补充",
-          "tank_not_installed": "清水箱未安装"
+          "no_water_left": "清水箱即將耗盡，請及時檢查並補充清水",
+          "no_water_left_after_clean": "拖布已清潔，偵測到清水不足，請補充清水並清空污水箱",
+          "no_water_for_clean": "清水箱水位過低，已切換至僅吸塵模式",
+          "low_water": "清水即將用盡，請及時補充",
+          "tank_not_installed": "清水箱未安裝"
         }
       },
       "stream_status": {
         "name": "實時串流狀態",
         "state": {
           "unknown": "未知",
-          "idle": "待机",
-          "video": "视频",
-          "audio": "音频",
-          "recording": "录像中"
+          "idle": "待機",
+          "video": "視訊",
+          "audio": "音訊",
+          "recording": "錄影中"
         }
       },
       "drainage_status": {
         "name": "排空狀態",
         "state": {
           "unknown": "未知",
-          "idle": "待机",
+          "idle": "待機",
           "draining": "排水中",
           "draining_successful": "排水完成",
-          "draining_failed": "排水失败"
+          "draining_failed": "排水失敗"
         }
       },
       "clean_water_tank_status": {
@@ -936,74 +936,74 @@
         "state": {
           "unknown": "未知",
           "not_available": "不可用",
-          "not_installed": "未安装",
+          "not_installed": "未安裝",
           "low_water": "水量低",
-          "installed": "已安装"
+          "installed": "已安裝"
         }
       },
       "dirty_water_tank_status": {
         "name": "污水箱狀態",
         "state": {
           "unknown": "未知",
-          "installed": "已安装",
-          "not_installed_or_full": "未安装或已满"
+          "installed": "已安裝",
+          "not_installed_or_full": "未安裝或已滿"
         }
       },
       "dust_bag_status": {
         "name": "塵袋狀態",
         "state": {
           "unknown": "未知",
-          "installed": "已安装",
-          "not_installed": "未安装",
-          "check": "需检查"
+          "installed": "已安裝",
+          "not_installed": "未安裝",
+          "check": "需檢查"
         }
       },
       "detergent_status": {
         "name": "清潔液狀態",
         "state": {
           "unknown": "未知",
-          "installed": "已安装",
-          "disabled": "禁用",
-          "low_detergent": "清洁液不足"
+          "installed": "已安裝",
+          "disabled": "停用",
+          "low_detergent": "清潔液不足"
         }
       },
       "hot_water_status": {
         "name": "熱水洗布狀態",
         "state": {
           "unknown": "未知",
-          "disabled": "禁用",
-          "enabled": "启用"
+          "disabled": "停用",
+          "enabled": "啟用"
         }
       },
       "station_drainage_status": {
         "name": "基站排空狀態",
         "state": {
           "unknown": "未知",
-          "idle": "待机",
+          "idle": "待機",
           "draining": "排水中"
         }
       },
       "task_type": {
         "name": "任務類型",
         "state": {
-          "standard": "标准清洁",
-          "standard_paused": "标准清洁暂停",
-          "custom": "自定义清洁",
-          "custom_paused": "自定义清洁暂停",
-          "shortcut": "快捷清洁",
-          "shortcut_paused": "快捷清洁暂停",
-          "scheduled": "预约清洁",
-          "scheduled_paused": "预约清洁暂停",
-          "smart": "智能清洁",
-          "smart_paused": "智能清洁暂停",
-          "partial": "局部清洁",
-          "partial_paused": "局部清洁暂停",
-          "summon": "召唤清洁",
-          "summon_paused": "召唤清洁暂停",
-          "water_stain": "水渍清洁模式",
-          "water_stain_paused": "水渍清洁暂停",
-          "boosted_edge_cleaning": "边角增强清洁",
-          "hair_compressing": "毛发压缩处理",
+          "standard": "標準清潔",
+          "standard_paused": "標準清潔暫停",
+          "custom": "自訂清潔",
+          "custom_paused": "自訂清潔暫停",
+          "shortcut": "快捷清潔",
+          "shortcut_paused": "快捷清潔暫停",
+          "scheduled": "預約清潔",
+          "scheduled_paused": "預約清潔暫停",
+          "smart": "智慧清潔",
+          "smart_paused": "智慧清潔暫停",
+          "partial": "局部清潔",
+          "partial_paused": "局部清潔暫停",
+          "summon": "召喚清潔",
+          "summon_paused": "召喚清潔暫停",
+          "water_stain": "水漬清潔模式",
+          "water_stain_paused": "水漬清潔暫停",
+          "boosted_edge_cleaning": "邊角增強清潔",
+          "hair_compressing": "毛髮壓縮處理",
           "large_particle_cleaning": "大顆粒清潔",
           "intensive_stain_cleaning": "強力污漬清潔",
           "stain_cleaning": "污漬清潔",
@@ -1030,7 +1030,7 @@
       "nation_matched": {
         "name": "區域鎖定",
         "state": {
-          "unknown": "已禁用",
+          "unknown": "已停用",
           "matched": "已解鎖",
           "unmatched": "已鎖定",
           "na": "不可用"
@@ -1061,9 +1061,9 @@
         "name": "清掃模式",
         "state": {
           "other": "其他",
-          "default": "默認",
+          "default": "預設",
           "customized": "定制",
-          "cleangenius": "智能託管",
+          "cleangenius": "智慧託管",
           "water_stain": "水漬",
           "unknown": "未知"
         }
@@ -1089,7 +1089,7 @@
           "brush_entangled_by_obstacle": "毛刷卡在障礙物",
           "cannot_find_base_station": "找不到基站",
           "cliff_sensor_error": "懸崖感應器錯誤",
-          "laser_distance_sensor_error": "激光感應器錯誤",
+          "laser_distance_sensor_error": "雷射感應器錯誤",
           "mop_pad_abnormally_removed": "拖布異常移除",
           "mop_pad_fallen_off": "拖布脫落",
           "mop_pad_fallen_off_by_obstacle": "因障礙物拖布脫落",
@@ -1127,12 +1127,12 @@
           "fece": "寵物便便",
           "trash_can": "垃圾桶",
           "fabric": "織物",
-          "power_strip": "插線板",
+          "power_strip": "電源延長線",
           "liquid_stain": "水漬",
           "obstacle": "障礙物",
           "pet": "寵物",
           "cleaning_tools": "清潔工具",
-          "detected_stain": "檢測到污漬",
+          "detected_stain": "偵測到污漬",
           "blocked_room": "阻塞房間",
           "easy_to_stuck_furniture": "易卡家具",
           "uncleanable_stain": "無法清潔污漬",
@@ -1142,7 +1142,7 @@
           "food_bowl": "食盆",
           "pet_bed": "寵物窩",
           "cleaned_stain": "污漬已清潔",
-          "skipped_uncleanable_stain": "跳過無法清潔污渍",
+          "skipped_uncleanable_stain": "跳過無法清潔污漬",
           "cleaned_dried_stain": "陳舊污漬已清潔",
           "cleaned_large_particles": "大顆粒已清潔",
           "pen": "筆"
@@ -1174,19 +1174,19 @@
         "name": "BSSID"
       },
       "firmware_version": {
-        "name": "固件版本"
+        "name": "韌體版本"
       },
       "ip_address": {
-        "name": "IP地址"
+        "name": "IP 位址"
       },
       "mac_address": {
-        "name": "MAC地址"
+        "name": "MAC 位址"
       },
       "model": {
         "name": "產品型號"
       },
       "rssi": {
-        "name": "信號強度"
+        "name": "訊號強度"
       },
       "serial_number": {
         "name": "序列號"
@@ -1500,7 +1500,7 @@
         "delete": "刪除",
         "delete_carpet": "刪除地毯",
         "deleted_carpet": "已刪除地毯",
-        "disable": "禁用",
+        "disable": "停用",
         "discard": "放棄",
         "dismiss": "忽略",
         "dock": "基站",
@@ -1519,7 +1519,7 @@
         "ignore_obstacle": "忽略障礙物",
         "impassable_threshold": "不可越門檻",
         "job_details": "任務詳情",
-        "keep_disabled": "保持禁用",
+        "keep_disabled": "保持停用",
         "map_management": "地圖管理",
         "new_dnd": "新勿擾任務",
         "new_schedule": "新預約清掃",
@@ -1565,7 +1565,7 @@
         "virtual_wall": "虛擬牆",
         "wash": "清洗",
         "washing_unavailable": "清洗不可用",
-        "wifi_map": "WiFi熱力圖"
+        "wifi_map": "WiFi 熱力圖"
       }
     },
     "frontend_config": {
@@ -1580,7 +1580,7 @@
         "card_object_information_notification": "資訊通知",
         "card_object_low_water_notification": "缺水通知",
         "card_object_map_change_confirmation": "地圖更改確認",
-        "card_object_menu": "菜單",
+        "card_object_menu": "選單",
         "card_object_progress_bar": "進度條",
         "card_object_saved_notification": "已儲存通知",
         "card_object_shortcuts": "快捷指令",
@@ -1600,7 +1600,7 @@
         "copied": "已複製",
         "copy": "複製",
         "copy_all": "複製全部",
-        "disable_haptic": "禁用觸感反饋",
+        "disable_haptic": "停用觸感回饋",
         "editable_objects": "可編輯對象",
         "font_size": "字體大小",
         "grid_size": "網格大小",
@@ -1620,7 +1620,7 @@
         "locked_always": "始終",
         "locked_auto": "自動",
         "locked_never": "從不",
-        "locked_only_touch": "僅觸摸",
+        "locked_only_touch": "僅觸控",
         "map": "地圖 %name%",
         "map_1": "第一張圖",
         "map_2": "第二張圖",
@@ -1655,8 +1655,8 @@
         "map_color_ramp": "坡道",
         "map_color_segment": "房間",
         "map_color_settings_background": "設定背景",
-        "map_color_text": "文本",
-        "map_color_text_stroke": "文本描邊",
+        "map_color_text": "文字",
+        "map_color_text_stroke": "文字描邊",
         "map_color_virtual_threshold": "虛擬門檻",
         "map_color_virtual_wall": "虛擬牆",
         "map_color_wall": "牆壁",
@@ -1755,7 +1755,7 @@
         "delete_schedule": "確認刪除預約清掃？",
         "delete_shortcut": "確認刪除快捷指令？",
         "deleted": "刪除成功",
-        "device_unavailable": "設備不可用",
+        "device_unavailable": "裝置不可用",
         "disable_cleangenius": "停用 CleanGenius？",
         "dnd_confliction": "勿擾任務衝突！",
         "dnd_confliction_detail": "預約清掃時間在勿擾時間段內。",
@@ -1800,7 +1800,7 @@
         "replace_map": "替換新地圖？",
         "reset_usage": "確認重設使用詳情？",
         "restore_map": "確認還原 %name%？",
-        "resume_cleaning": "主機會在電量充至80%後自動繼續執行未完成的清掃任務。",
+        "resume_cleaning": "主機會在電量充至 80% 後自動繼續執行未完成的清掃任務。",
         "resume_cleaning_not_performed": "主機將在勿擾結束後恢復清掃。",
         "resume_cleaning_time": "將在 %time% 開始清掃",
         "save_changes": "確認儲存更改？",
@@ -1842,8 +1842,8 @@
         "description": "%name% 客製化整合的插件前端",
         "detected_carpet": "識別地毯",
         "detergent": "清潔液",
-        "device_information": "設備資訊",
-        "device_settings": "設備設定",
+        "device_information": "裝置資訊",
+        "device_settings": "裝置設定",
         "dnd": "勿擾模式",
         "dnd_task": "勿擾任務",
         "dust_bag": "塵袋",
@@ -1866,7 +1866,7 @@
         "saved_map": "已儲存地圖",
         "schedule_list": "預約清掃",
         "scheduled_room": "預約選區清掃",
-        "scheduled_spot": "預約指點清扫",
+        "scheduled_spot": "預約指點清掃",
         "scheduled_task": "預約任務",
         "scheduled_zone": "預約劃區清掃",
         "segment_name_placeholder": "房間 %index%",
@@ -1880,492 +1880,492 @@
         "time_left": "剩餘 %time%",
         "unavailable": "不可用",
         "used_water_tank": "污水箱",
-        "wifi_map": "WiFi熱力圖"
+        "wifi_map": "WiFi 熱力圖"
       }
     }
   },
   "services": {
     "vacuum_clean_segment": {
-      "name": "分区清洁",
-      "description": "对选定房间启动清洁任务",
+      "name": "分區清潔",
+      "description": "對選定房間啟動清潔任務",
       "fields": {
         "segments": {
-          "name": "清洁区域",
-          "description": "待清洁房间列表。可单独设置每个房间的标识符，或通过数组为每个房间覆盖默认的清洁次数、吸力强度和拖地模式"
+          "name": "清潔區域",
+          "description": "待清潔房間清單。可單獨設定每個房間的識別碼，或透過陣列為每個房間覆寫預設的清潔次數、吸力強度和拖地模式"
         },
         "repeats": {
-          "name": "清洁次数",
-          "description": "每个选定房间的清洁次数（除非被自定义参数覆盖）"
+          "name": "清潔次數",
+          "description": "每個選定房間的清潔次數（除非被自訂參數覆寫）"
         },
         "suction_level": {
-          "name": "吸力强度",
-          "description": "每个选定房间的吸力强度（除非被自定义参数覆盖）"
+          "name": "吸力強度",
+          "description": "每個選定房間的吸力強度（除非被自訂參數覆寫）"
         },
         "water_volume": {
           "name": "出水量",
-          "description": "每个选定房间的拖地水量（除非被自定义参数覆盖）"
+          "description": "每個選定房間的拖地水量（除非被自訂參數覆寫）"
         }
       }
     },
     "vacuum_clean_zone": {
-      "name": "区域清洁",
-      "description": "对选定区域启动清洁任务",
+      "name": "區域清潔",
+      "description": "對選定區域啟動清潔任務",
       "fields": {
         "zone": {
-          "name": "清洁区域",
-          "description": "区域坐标范围"
+          "name": "清潔區域",
+          "description": "區域座標範圍"
         },
         "repeats": {
-          "name": "清洁次数",
-          "description": "每个选定区域的清洁遍数"
+          "name": "清潔次數",
+          "description": "每個選定區域的清潔遍數"
         },
         "suction_level": {
-          "name": "吸力强度",
-          "description": "每个选定区域的吸力档位"
+          "name": "吸力強度",
+          "description": "每個選定區域的吸力檔位"
         },
         "water_volume": {
           "name": "出水量",
-          "description": "每个选定区域的拖地水量"
+          "description": "每個選定區域的拖地水量"
         }
       }
     },
     "vacuum_clean_spot": {
-      "name": "定点清洁",
-      "description": "对地图上选定的坐标点启动清洁任务",
+      "name": "定點清潔",
+      "description": "對地圖上選定的座標點啟動清潔任務",
       "fields": {
         "points": {
-          "name": "坐标点",
-          "description": "待清洁的坐标点列表"
+          "name": "座標點",
+          "description": "待清潔的座標點清單"
         },
         "repeats": {
-          "name": "清洁次数",
-          "description": "每个坐标点的清洁遍数"
+          "name": "清潔次數",
+          "description": "每個座標點的清潔遍數"
         },
         "suction_level": {
-          "name": "吸力强度",
-          "description": "每个坐标点的吸力档位"
+          "name": "吸力強度",
+          "description": "每個座標點的吸力檔位"
         },
         "water_volume": {
           "name": "出水量",
-          "description": "每个坐标点的拖地水量"
+          "description": "每個座標點的拖地水量"
         }
       }
     },
     "vacuum_goto": {
       "name": "前往",
-      "description": "前往地图坐标点并停止",
+      "description": "前往地圖座標點並停止",
       "fields": {
         "x": {
-          "name": "X坐标",
-          "description": "X轴坐标值"
+          "name": "X 座標",
+          "description": "X 軸座標值"
         },
         "y": {
-          "name": "Y坐标",
-          "description": "Y轴坐标值"
+          "name": "Y 座標",
+          "description": "Y 軸座標值"
         }
       }
     },
     "vacuum_follow_path": {
-      "name": "路径巡航",
-      "description": "按照地图上的坐标列表移动并返回基站（仅支持带视觉导航的机型）",
+      "name": "路徑巡航",
+      "description": "按照地圖上的座標清單移動並返回基站（僅支援帶視覺導航的機型）",
       "fields": {
         "points": {
-          "name": "坐标点",
-          "description": "目标路径的坐标点集合"
+          "name": "座標點",
+          "description": "目標路徑的座標點集合"
         }
       }
     },
     "vacuum_start_shortcut": {
-      "name": "执行快捷指令",
-      "description": "启动预设的快捷任务（仅支持部分机型）",
+      "name": "執行快捷指令",
+      "description": "啟動預設的快捷任務（僅支援部分機型）",
       "fields": {
         "shortcut_id": {
-          "name": "指令编号",
-          "description": "快捷指令的唯一标识码"
+          "name": "指令編號",
+          "description": "快捷指令的唯一識別碼"
         }
       }
     },
     "vacuum_remote_control_move_step": {
-      "name": "遥控单步移动",
-      "description": "远程控制设备执行单步移动指令",
+      "name": "遙控單步移動",
+      "description": "遠端控制裝置執行單步移動指令",
       "fields": {
         "rotation": {
-          "name": "转向角度",
-          "description": "转向角度值（二进制角度制），范围-128至128"
+          "name": "轉向角度",
+          "description": "轉向角度值（二進位角度制），範圍 -128 至 128"
         },
         "velocity": {
-          "name": "移动速度",
-          "description": "移动速度值，100（前进）至-300（后退）"
+          "name": "移動速度",
+          "description": "移動速度值，100（前進）至 -300（後退）"
         }
       }
     },
     "vacuum_install_voice_pack": {
-      "name": "安装语音包",
-      "description": "安装官方或自定义语音包",
+      "name": "安裝語音包",
+      "description": "安裝官方或自訂語音包",
       "fields": {
         "lang_id": {
-          "name": "语言ID",
-          "description": "语音包对应的语言标识码"
+          "name": "語言 ID",
+          "description": "語音包對應的語言識別碼"
         },
         "url": {
-          "name": "下载地址",
-          "description": "语音包下载链接"
+          "name": "下載位址",
+          "description": "語音包下載連結"
         },
         "md5": {
-          "name": "MD5校验码",
-          "description": "语音包的MD5校验值"
+          "name": "MD5 校驗碼",
+          "description": "語音包的 MD5 校驗值"
         },
         "size": {
-          "name": "文件大小",
-          "description": "语音包体积（单位：字节）"
+          "name": "檔案大小",
+          "description": "語音包容量（單位：位元組）"
         }
       }
     },
     "vacuum_request_map": {
-      "name": "请求地图数据",
-      "description": "获取当前地图数据"
+      "name": "請求地圖資料",
+      "description": "取得目前地圖資料"
     },
     "vacuum_select_map": {
-      "name": "选择地图",
-      "description": "选择当前使用的地图（适用于多地图/多层场景）",
+      "name": "選擇地圖",
+      "description": "選擇目前使用的地圖（適用於多地圖／多層場景）",
       "fields": {
         "map_id": {
-          "name": "地图ID",
-          "description": "选择地图的唯一标识码"
+          "name": "地圖 ID",
+          "description": "選擇地圖的唯一識別碼"
         }
       }
     },
     "vacuum_delete_map": {
-      "name": "删除地图",
-      "description": "永久删除指定地图数据",
+      "name": "刪除地圖",
+      "description": "永久刪除指定地圖資料",
       "fields": {
         "map_id": {
-          "name": "地图ID",
-          "description": "待删除地图的唯一标识码"
+          "name": "地圖 ID",
+          "description": "待刪除地圖的唯一識別碼"
         }
       }
     },
     "vacuum_save_temporary_map": {
-      "name": "保存临时地图",
-      "description": "将当前临时地图保存为正式地图"
+      "name": "儲存暫時地圖",
+      "description": "將目前暫時地圖儲存為正式地圖"
     },
     "vacuum_discard_temporary_map": {
-      "name": "丢弃临时地图",
-      "description": "永久清除当前临时地图数据"
+      "name": "捨棄暫時地圖",
+      "description": "永久清除目前暫時地圖資料"
     },
     "vacuum_replace_temporary_map": {
-      "name": "替换临时地图",
-      "description": "用其他已保存地图替换当前临时地图",
+      "name": "取代暫時地圖",
+      "description": "用其他已儲存地圖取代目前暫時地圖",
       "fields": {
         "map_id": {
-          "name": "目标地图ID",
-          "description": "用于替换临时地图的已存地图标识码"
+          "name": "目標地圖 ID",
+          "description": "用於取代暫時地圖的已存地圖識別碼"
         }
       }
     },
     "vacuum_rename_map": {
-      "name": "地图重命名",
-      "description": "修改指定地图的名称",
+      "name": "地圖重新命名",
+      "description": "修改指定地圖的名稱",
       "fields": {
         "map_id": {
-          "name": "地图ID",
-          "description": "需要重命名的地图标识码"
+          "name": "地圖 ID",
+          "description": "需要重新命名的地圖識別碼"
         },
         "map_name": {
-          "name": "新地图名称",
-          "description": "地图的新命名（支持中文、字母和数字）"
+          "name": "新地圖名稱",
+          "description": "地圖的新命名（支援中文、字母和數字）"
         }
       }
     },
     "vacuum_restore_map": {
-      "name": "恢复地图",
-      "description": "从备份恢复指定地图数据",
+      "name": "還原地圖",
+      "description": "從備份還原指定地圖資料",
       "fields": {
         "map_id": {
-          "name": "目标地图ID",
-          "description": "待恢复地图的标识码"
+          "name": "目標地圖 ID",
+          "description": "待還原地圖的識別碼"
         },
         "recovery_map_index": {
-          "name": "恢复点序号",
-          "description": "备份地图的版本索引号"
+          "name": "還原點序號",
+          "description": "備份地圖的版本索引號"
         }
       }
     },
     "vacuum_restore_map_from_file": {
-      "name": "从文件恢复地图",
-      "description": "从本地文件恢复地图数据",
+      "name": "從檔案還原地圖",
+      "description": "從本地檔案還原地圖資料",
       "fields": {
         "map_id": {
-          "name": "地图ID",
-          "description": "需要恢复的地图编号"
+          "name": "地圖 ID",
+          "description": "需要還原的地圖編號"
         },
         "file_url": {
-          "name": "文件URL",
-          "description": "已保存的.bz2.gz或.tar.gz压缩文件地址"
+          "name": "檔案 URL",
+          "description": "已儲存的 .bz2.gz 或 .tar.gz 壓縮檔位址"
         }
       }
     },
     "vacuum_backup_map": {
-      "name": "备份地图至云端",
-      "description": "将当前地图备份到云存储",
+      "name": "備份地圖至雲端",
+      "description": "將目前地圖備份至雲端儲存",
       "fields": {
         "map_id": {
-          "name": "地图ID",
-          "description": "需要备份的地图编号"
+          "name": "地圖 ID",
+          "description": "需要備份的地圖編號"
         }
       }
     },
     "vacuum_merge_segments": {
-      "name": "合并区域",
-      "description": "合并多个房间区域",
+      "name": "合併區域",
+      "description": "合併多個房間區域",
       "fields": {
         "map_id": {
-          "name": "地图ID",
-          "description": "目标地图编号"
+          "name": "地圖 ID",
+          "description": "目標地圖編號"
         },
         "segments": {
-          "name": "区域",
-          "description": "需要合并的房间ID"
+          "name": "區域",
+          "description": "需要合併的房間 ID"
         }
       }
     },
     "vacuum_split_segments": {
-      "name": "分割区域",
-      "description": "将现有房间区域拆分为多个独立区域",
+      "name": "分割區域",
+      "description": "將現有房間區域拆分為多個獨立區域",
       "fields": {
         "map_id": {
-          "name": "地图ID",
-          "description": "目标地图编号"
+          "name": "地圖 ID",
+          "description": "目標地圖編號"
         },
         "segment": {
-          "name": "区域",
-          "description": "需要分割的原始房间编号"
+          "name": "區域",
+          "description": "需要分割的原始房間編號"
         },
         "line": {
-          "name": "分割线",
-          "description": "分割线坐标"
+          "name": "分割線",
+          "description": "分割線座標"
         }
       }
     },
     "vacuum_rename_segment": {
-      "name": "重命名区域",
-      "description": "修改指定区域的名称",
+      "name": "重新命名區域",
+      "description": "修改指定區域的名稱",
       "fields": {
         "segment_id": {
-          "name": "区域ID",
-          "description": "需要重命名的区域编号"
+          "name": "區域 ID",
+          "description": "需要重新命名的區域編號"
         },
         "segment_name": {
-          "name": "新区域名称",
-          "description": "为该区域设置的新名称"
+          "name": "新區域名稱",
+          "description": "為該區域設定的新名稱"
         }
       }
     },
     "vacuum_set_cleaning_sequence": {
-      "name": "设置清洁区域顺序",
-      "description": "设置房间清洁顺序（仅支持部分机型）",
+      "name": "設定清潔區域順序",
+      "description": "設定房間清潔順序（僅支援部分機型）",
       "fields": {
         "cleaning_sequence": {
-          "name": "清洁顺序",
-          "description": "按顺序排列的区域ID列表"
+          "name": "清潔順序",
+          "description": "按順序排列的區域 ID 清單"
         }
       }
     },
     "vacuum_set_custom_cleaning": {
-      "name": "设置自定义清洁",
-      "description": "设置个性化清洁参数（仅限支持机型）",
+      "name": "設定自訂清潔",
+      "description": "設定個性化清潔參數（僅限支援機型）",
       "fields": {
         "segment_id": {
-          "name": "区域ID",
-          "description": "目标房间编号"
+          "name": "區域 ID",
+          "description": "目標房間編號"
         },
         "suction_level": {
-          "name": "吸力等级",
-          "description": "各房间对应的吸力强度"
+          "name": "吸力等級",
+          "description": "各房間對應的吸力強度"
         },
         "water_volume": {
           "name": "出水量",
-          "description": "各房间对应的拖地水量"
+          "description": "各房間對應的拖地水量"
         },
         "wetness_level": {
-          "name": "拖布湿润度",
-          "description": "为每个房间设置拖地湿度（仅支持部分机型）"
+          "name": "拖布濕潤度",
+          "description": "為每個房間設定拖地濕度（僅支援部分機型）"
         },
         "cleaning_mode": {
-          "name": "清洁模式",
-          "description": "各房间的清洁方式（需设备支持拖布抬升功能）"
+          "name": "清潔模式",
+          "description": "各房間的清潔方式（需裝置支援拖布抬升功能）"
         },
         "repeats": {
-          "name": "重复次数",
-          "description": "各房间的清洁遍数"
+          "name": "重複次數",
+          "description": "各房間的清潔遍數"
         }
       }
     },
     "vacuum_set_custom_carpet_cleaning": {
-      "name": "设置自定义地毯清洁",
-      "description": "为地毯设置自定义清洁设置。（仅支持的设备）",
+      "name": "設定自訂地毯清潔",
+      "description": "為地毯設定自訂清潔設定。（僅支援的裝置）",
       "fields": {
         "id": {
-          "name": "地毯ID",
-          "description": "地毯ID列表。"
+          "name": "地毯 ID",
+          "description": "地毯 ID 清單。"
         },
         "type": {
-          "name": "对象类型",
-          "description": "带ID对象的类型。（0 = 自动检测地毯，1 = 手动创建地毯，2 = 房间地毯（如果支持））"
+          "name": "對象類型",
+          "description": "帶 ID 對象的類型。（0 = 自動偵測地毯，1 = 手動建立地毯，2 = 房間地毯（若支援））"
         },
         "carpet_cleaning": {
-          "name": "地毯清洁",
-          "description": "每个地毯的自定义清洁设置。"
+          "name": "地毯清潔",
+          "description": "每個地毯的自訂清潔設定。"
         },
         "carpet_preferences": {
-          "name": "地毯设置",
-          "description": "每个地毯的自定义设置，包含启用设置的数组。"
+          "name": "地毯設定",
+          "description": "每個地毯的自訂設定，包含啟用設定的陣列。"
         }
       }
     },
     "vacuum_set_restricted_zone": {
-      "name": "设置限制区域",
-      "description": " 定义虚拟墙、限制区域和/或禁拖区域。",
+      "name": "設定限制區域",
+      "description": "定義虛擬牆、限制區域和／或禁拖區域。",
       "fields": {
         "walls": {
-          "name": "墙壁",
-          "description": "虚拟墙。"
+          "name": "牆壁",
+          "description": "虛擬牆。"
         },
         "zones": {
-          "name": "区域",
-          "description": "禁止进入区域。"
+          "name": "區域",
+          "description": "禁止進入區域。"
         },
         "no_mops": {
-          "name": "禁拖区域",
-          "description": "禁拖区域。"
+          "name": "禁拖區域",
+          "description": "禁拖區域。"
         }
       }
     },
     "vacuum_reset_consumable": {
-      "name": "重设耗材",
-      "description": "重设耗材。",
+      "name": "重設耗材",
+      "description": "重設耗材。",
       "fields": {
         "consumable": {
           "name": "耗材",
-          "description": "耗材类型。"
+          "description": "耗材類型。"
         }
       }
     },
     "vacuum_rename_shortcut": {
-      "name": "重新命名快捷方式",
-      "description": "重新命名快捷方式。(仅支持特定设备)",
+      "name": "重新命名快捷指令",
+      "description": "重新命名快捷指令。（僅支援特定裝置）",
       "fields": {
         "shortcut_id": {
-          "name": "快捷方式 ID",
-          "description": "快捷方式 ID。"
+          "name": "快捷指令 ID",
+          "description": "快捷指令 ID。"
         },
         "shortcut_name": {
-          "name": "快捷方式名称",
-          "description": "快捷方式的新名称。"
+          "name": "快捷指令名稱",
+          "description": "快捷指令的新名稱。"
         }
       }
     },
     "vacuum_delete_shortcut": {
-      "name": "刪除捷徑",
-      "description": "刪除捷徑。（僅限支援的裝置）",
+      "name": "刪除快捷指令",
+      "description": "刪除快捷指令。（僅限支援的裝置）",
       "fields": {
         "shortcut_id": {
-          "name": "捷徑 ID",
-          "description": "捷徑的 ID。"
+          "name": "快捷指令 ID",
+          "description": "快捷指令的 ID。"
         }
       }
     },
     "vacuum_set_carpet_area": {
-      "name": "设置地毯区域",
-      "description": "定义地毯和忽略的地毯。(仅支持特定设备)",
+      "name": "設定地毯區域",
+      "description": "定義地毯和忽略的地毯。（僅支援特定裝置）",
       "fields": {
         "carpets": {
           "name": "地毯",
-          "description": "地毯区域。"
+          "description": "地毯區域。"
         },
         "deleted_carpets": {
           "name": "忽略的地毯",
-          "description": "忽略的地毯区域，用于删除自动侦测到的地毯。"
+          "description": "忽略的地毯區域，用於刪除自動偵測到的地毯。"
         }
       }
     },
     "vacuum_set_virtual_threshold": {
-      "name": "设置虚拟门坎",
-      "description": "定义虚拟门坎。",
+      "name": "設定虛擬門檻",
+      "description": "定義虛擬門檻。",
       "fields": {
         "virtual_thresholds": {
-          "name": "虚拟门坎",
-          "description": "虚拟门坎线的坐标。"
+          "name": "虛擬門檻",
+          "description": "虛擬門檻線的座標。"
         }
       }
     },
     "vacuum_set_predefined_points": {
-      "name": "设置预设点",
-      "description": "在当前地图上定义预设坐标。(仅支持具有相机的扫地机)",
+      "name": "設定預設點",
+      "description": "在目前地圖上定義預設座標。（僅支援具有攝影機的掃地機）",
       "fields": {
         "points": {
-          "name": "坐标点",
-          "description": "要储存的坐标列表。"
+          "name": "座標點",
+          "description": "要儲存的座標清單。"
         }
       }
     },
     "vacuum_set_obstacle_ignore": {
-      "name": "设置障碍物忽略",
-      "description": "设置障碍物的忽略状态。(仅支持具有 AI 障碍物侦测功能的扫地机)",
+      "name": "設定障礙物忽略",
+      "description": "設定障礙物的忽略狀態。（僅支援具有 AI 障礙物偵測功能的掃地機）",
       "fields": {
         "x": {
           "name": "X",
-          "description": "障碍物的 X 坐标。"
+          "description": "障礙物的 X 座標。"
         },
         "y": {
           "name": "Y",
-          "description": "障碍物的 Y 坐标。"
+          "description": "障礙物的 Y 座標。"
         },
         "obstacle_ignored": {
-          "name": "忽略障碍物",
-          "description": "是否要忽略障碍物。"
+          "name": "忽略障礙物",
+          "description": "是否要忽略障礙物。"
         }
       }
     },
     "vacuum_set_router_position": {
-      "name": "设置路径点",
-      "description": "在当前地图上设置路径点。(仅支持有WiFi地图功能的扫地机)",
+      "name": "設定路徑點",
+      "description": "在目前地圖上設定路徑點。（僅支援有 WiFi 地圖功能的掃地機）",
       "fields": {
         "x": {
           "name": "X",
-          "description": "路径的 X 坐标。"
+          "description": "路徑的 X 座標。"
         },
         "y": {
           "name": "Y",
-          "description": "路径的 Y 坐标。"
+          "description": "路徑的 Y 座標。"
         }
       }
     },
     "select_select_previous": {
-      "name": "选择前一个",
-      "description": "选择选项实体的前一个选项。",
+      "name": "選擇前一個",
+      "description": "選擇選項實體的前一個選項。",
       "fields": {
         "cycle": {
-          "name": "循环",
-          "description": "选项是否应该从第一个循环到最后一个。"
+          "name": "循環",
+          "description": "選項是否應該從第一個循環到最後一個。"
         }
       }
     },
     "select_select_first": {
-      "name": "选择第一个",
-      "description": "选择选项实体的第一个选项。"
+      "name": "選擇第一個",
+      "description": "選擇選項實體的第一個選項。"
     },
     "select_select_last": {
-      "name": "选择最后一个",
-      "description": "选择选项实体的最后一个选项。"
+      "name": "選擇最後一個",
+      "description": "選擇選項實體的最後一個選項。"
     },
     "select_select_next": {
-      "name": "选择下一个",
-      "description": "选择选项实体的下一个选项。",
+      "name": "選擇下一個",
+      "description": "選擇選項實體的下一個選項。",
       "fields": {
         "cycle": {
-          "name": "循环",
-          "description": "选项是否应该从第一个循环到最后一个。"
+          "name": "循環",
+          "description": "選項是否應該從第一個循環到最後一個。"
         }
       }
     }


### PR DESCRIPTION
## Problem
The existing `zh-Hant.json` file was almost entirely written in Simplified
Chinese rather than Traditional Chinese, making it effectively a duplicate
of `zh-Hans.json` with only a handful of traditional characters mixed in.

## Changes
Rewrote `zh-Hant.json` from scratch using proper Traditional Chinese with
Taiwan-specific wording throughout the entire file, covering all sections:
`config`, `options`, `entity`, `entity_component`, and `services`.
Key Taiwan-specific vocabulary applied consistently:
| Category | Before (Simplified) | After (Taiwan Traditional) |
|---|---|---|
| Device | 设备 | 裝置 |
| Login | 登录 | 登入 |
| Account | 账号 | 帳號 |
| Username | 用户名 | 使用者名稱 |
| Server | 服务器 | 伺服器 |
| Cloud connection | 云端连接 | 雲端連線 |
| Settings/Configure | 配置 / 设置 | 設定 |
| Support | 支持 | 支援 |
| Detect | 检测 | 偵測 |
| Firmware | 固件 | 韌體 |
| Signal strength | 信号强度 | 訊號強度 |
| IP/MAC address | IP/MAC地址 | IP/MAC 位址 |
| Coordinate | 坐标 | 座標 |
| File | 文件 | 檔案 |
| Array | 数组 | 陣列 |
| Bathroom | 卫生间 | 浴室 |
| Power strip | 插线板 | 電源延長線 |
| UI Menu | 菜单 | 選單 |
| Touch | 触摸 | 觸控 |
| Feedback | 反馈 | 回饋 |
| Default | 默认 | 預設 |
| Smart/Intelligent | 智能 | 智慧 |
| Disable | 禁用 | 停用 |
All simplified character forms have been converted to their traditional
equivalents (e.g. 关→關, 连→連, 标→標, 检→檢, 传→傳, 设→設, etc.).