### PR TITLE
Fix auto-empty base capability detection

### DIFF
--- a/custom_components/dreame_vacuum/dreame/const.py
+++ b/custom_components/dreame_vacuum/dreame/const.py
@@ -236,6 +236,7 @@ CHARGING_STATUS_CHARGING_COMPLETED: Final = "charging_completed"
 
 DUST_COLLECTION_NOT_AVAILABLE: Final = "not_available"
 DUST_COLLECTION_AVAILABLE: Final = "available"
+DUST_COLLECTION_OVER_USE: Final = "over_use"
 
 AUTO_EMPTY_STATUS_ACTIVE: Final = "active"
 AUTO_EMPTY_STATUS_NOT_PERFORMED: Final = "not_performed"
@@ -1482,6 +1483,7 @@ DUST_COLLECTION_TO_NAME: Final = {
     DreameVacuumDustCollection.UNKNOWN: STATE_UNKNOWN,
     DreameVacuumDustCollection.NOT_AVAILABLE: DUST_COLLECTION_NOT_AVAILABLE,
     DreameVacuumDustCollection.AVAILABLE: DUST_COLLECTION_AVAILABLE,
+    DreameVacuumDustCollection.OVER_USE: DUST_COLLECTION_OVER_USE,
 }
 
 AUTO_EMPTY_STATUS_TO_NAME: Final = {

--- a/custom_components/dreame_vacuum/dreame/types.py
+++ b/custom_components/dreame_vacuum/dreame/types.py
@@ -3153,9 +3153,9 @@ class DreameVacuumDeviceCapability:
 
         if self.self_wash_base and self.washless_base:
             self.self_wash_base = False
-        if self.auto_empty_base and (
-            not self.auto_emptying
-            or self._device.get_property(DreameVacuumProperty.DUST_COLLECTION)
+        if (
+            self.auto_empty_base
+            and self._device.get_property(DreameVacuumProperty.DUST_COLLECTION)
             == DreameVacuumDustCollection.NEVER.value
         ):
             self.auto_empty_base = False


### PR DESCRIPTION
## Summary
- keep auto-empty base support when the dust collection property exists, even if the newer AUTO_EMPTYING capability flag is absent
- map the dust collection over-use status to the existing translated over_use state

## Testing
- python -m py_compile custom_components/dreame_vacuum/dreame/const.py custom_components/dreame_vacuum/dreame/types.py
- installed patched HACS test release in Home Assistant and verified the Start Auto Empty entity loads
- verified repeated Start Auto Empty runs and confirmed dust collection over-use now reports as over_use instead of unknown