### PR TITLE
Add low lying area map editing

### DIFF
--- a/custom_components/dreame_vacuum/dreame/device.py
+++ b/custom_components/dreame_vacuum/dreame/device.py
@@ -6521,13 +6521,13 @@ class DreameVacuumDevice:
             areas = []
 
         if self._map_manager:
-            if self.status.current_map and self.status.current_map.low_lying_areas is None:
+            if not self.capability.low_lying_areas:
                 raise InvalidActionException("Low lying areas are not supported on this device")
 
             if self.status.current_map and not self.status.has_saved_map:
                 raise InvalidActionException("Cannot edit low lying areas on current map")
 
-            raise InvalidActionException("Low lying area editing not supported yet!")
+            return self.update_map_data_async(self._map_manager.editor.set_low_lying_areas(areas))
 
     def set_predefined_points(self, points=[]) -> dict[str, Any] | None:
         """Set predefined points on current saved map."""

--- a/custom_components/dreame_vacuum/dreame/map.py
+++ b/custom_components/dreame_vacuum/dreame/map.py
@@ -2577,6 +2577,7 @@ class DreameMapVacuumMapEditor:
             )
 
         map_data.low_lying_areas = low_lying_areas
+        low_lying_area_key = map_data.low_lying_area_key or "sneak_areas_end"
 
         self._set_updated_frame_id(map_data.frame_id)
         if (
@@ -2585,18 +2586,20 @@ class DreameMapVacuumMapEditor:
             and self._selected_map_id in self._saved_map_data
         ):
             self._saved_map_data[self._selected_map_id].low_lying_areas = map_data.low_lying_areas
+            self._saved_map_data[self._selected_map_id].low_lying_area_key = low_lying_area_key
             self.refresh_map(self._selected_map_id)
         self.refresh_map()
 
+        areas_payload = [
+            {
+                "id": area.id,
+                "roi": area.polygon,
+                "type": area.type,
+            }
+            for area in map_data.low_lying_areas
+        ]
         return {
-            "sneak_areas": [
-                {
-                    "id": area.id,
-                    "roi": area.polygon,
-                    "type": area.type,
-                }
-                for area in map_data.low_lying_areas
-            ]
+            low_lying_area_key: areas_payload,
         }
 
     def set_predefined_points(self, predefined_points) -> None:
@@ -5399,8 +5402,13 @@ class DreameVacuumMapDecoder:
                     )
 
             low_lying_area_key = "sneak_areas_end" if "sneak_areas_end" in data_json else "sneak_areas"
+            map_data.low_lying_area_key = low_lying_area_key
             low_lying_areas = (
-                changes["sneak_areas"] if changes and "sneak_areas" in changes else data_json.get(low_lying_area_key)
+                changes.get(low_lying_area_key)
+                or changes.get("sneak_areas_end")
+                or changes.get("sneak_areas")
+                if changes
+                else data_json.get(low_lying_area_key)
             )
 
             if low_lying_areas and not map_data.low_lying_areas:

--- a/custom_components/dreame_vacuum/dreame/map.py
+++ b/custom_components/dreame_vacuum/dreame/map.py
@@ -2541,6 +2541,64 @@ class DreameMapVacuumMapEditor:
             self.refresh_map(self._selected_map_id)
         self.refresh_map()
 
+    def set_low_lying_areas(self, areas) -> dict[str, list[dict[str, Any]]] | None:
+        map_data = self._map_data
+        if not map_data or not self._selected_map_id:
+            return
+
+        low_lying_areas = []
+        for index, area in enumerate(areas or [], 1):
+            x_coords = sorted([area[0], area[2]])
+            y_coords = sorted([area[1], area[3]])
+            polygon = [
+                x_coords[0],
+                y_coords[0],
+                x_coords[1],
+                y_coords[0],
+                x_coords[1],
+                y_coords[1],
+                x_coords[0],
+                y_coords[1],
+            ]
+            low_lying_areas.append(
+                Polygon(
+                    index,
+                    x_coords[0],
+                    y_coords[0],
+                    x_coords[1],
+                    y_coords[0],
+                    x_coords[1],
+                    y_coords[1],
+                    x_coords[0],
+                    y_coords[1],
+                    polygon,
+                    1,
+                )
+            )
+
+        map_data.low_lying_areas = low_lying_areas
+
+        self._set_updated_frame_id(map_data.frame_id)
+        if (
+            self._saved_map_data
+            and self._selected_map_id is not None
+            and self._selected_map_id in self._saved_map_data
+        ):
+            self._saved_map_data[self._selected_map_id].low_lying_areas = map_data.low_lying_areas
+            self.refresh_map(self._selected_map_id)
+        self.refresh_map()
+
+        return {
+            "sneak_areas": [
+                {
+                    "id": area.id,
+                    "roi": area.polygon,
+                    "type": area.type,
+                }
+                for area in map_data.low_lying_areas
+            ]
+        }
+
     def set_predefined_points(self, predefined_points) -> None:
         map_data = self._map_data
         if not map_data or not self._selected_map_id or map_data.predefined_points is None:

--- a/custom_components/dreame_vacuum/dreame/map.py
+++ b/custom_components/dreame_vacuum/dreame/map.py
@@ -2550,6 +2550,7 @@ class DreameMapVacuumMapEditor:
         for index, area in enumerate(areas or [], 1):
             x_coords = sorted([area[0], area[2]])
             y_coords = sorted([area[1], area[3]])
+            area_size = round(abs((x_coords[1] - x_coords[0]) * (y_coords[1] - y_coords[0])) / 1000000, 2)
             polygon = [
                 x_coords[0],
                 y_coords[0],
@@ -2573,6 +2574,9 @@ class DreameMapVacuumMapEditor:
                     y_coords[1],
                     polygon,
                     1,
+                    0,
+                    None,
+                    area_size,
                 )
             )
 
@@ -2595,6 +2599,8 @@ class DreameMapVacuumMapEditor:
                 "id": area.id,
                 "roi": area.polygon,
                 "type": area.type,
+                "hide": area.hidden,
+                "area": area.area,
             }
             for area in map_data.low_lying_areas
         ]

--- a/custom_components/dreame_vacuum/dreame/map.py
+++ b/custom_components/dreame_vacuum/dreame/map.py
@@ -2583,7 +2583,7 @@ class DreameMapVacuumMapEditor:
             )
 
         map_data.low_lying_areas = low_lying_areas
-        low_lying_area_key = map_data.low_lying_area_key or "sneak_areas_end"
+        low_lying_area_key = map_data.low_lying_area_key or "sneak_areas"
 
         self._set_updated_frame_id(map_data.frame_id)
         if (
@@ -2602,15 +2602,10 @@ class DreameMapVacuumMapEditor:
                 "roi": area.polygon,
                 "type": area.type,
                 "hide": area.hidden,
-                "area": area.area,
             }
             for area in map_data.low_lying_areas
         ]
-        return {
-            low_lying_area_key: areas_payload,
-            "sneak_areas": areas_payload,
-            "sneak_areas_end": areas_payload,
-        }
+        return {low_lying_area_key: areas_payload}
 
     def set_predefined_points(self, predefined_points) -> None:
         map_data = self._map_data

--- a/custom_components/dreame_vacuum/dreame/map.py
+++ b/custom_components/dreame_vacuum/dreame/map.py
@@ -911,6 +911,8 @@ class DreameMapVacuumMapManager:
                         map_data.no_go_areas = saved_map_data.no_go_areas
                         map_data.no_mopping_areas = saved_map_data.no_mopping_areas
                         map_data.virtual_walls = saved_map_data.virtual_walls
+                        map_data.low_lying_areas = saved_map_data.low_lying_areas
+                        map_data.low_lying_area_key = saved_map_data.low_lying_area_key
                         map_data.robot_position = None
                         map_data.docked = True
                         # map_data.restored_map = True
@@ -2606,6 +2608,8 @@ class DreameMapVacuumMapEditor:
         ]
         return {
             low_lying_area_key: areas_payload,
+            "sneak_areas": areas_payload,
+            "sneak_areas_end": areas_payload,
         }
 
     def set_predefined_points(self, predefined_points) -> None:
@@ -4949,6 +4953,8 @@ class DreameVacuumMapDecoder:
                         map_data.detected_carpets = saved_map_data.detected_carpets
                         map_data.router_position = saved_map_data.router_position
                         map_data.curtains = saved_map_data.curtains
+                        map_data.low_lying_areas = saved_map_data.low_lying_areas
+                        map_data.low_lying_area_key = saved_map_data.low_lying_area_key
                         map_data.hidden_segments = saved_map_data.hidden_segments
                         map_data.predefined_points = saved_map_data.predefined_points
                         map_data.cleaning_sequence = saved_map_data.cleaning_sequence
@@ -5579,6 +5585,8 @@ class DreameVacuumMapDecoder:
                         map_data.deleted_obstacles = deleted_objects["ai_obstacle"]
                     if "sneak_areas" in deleted_objects:
                         map_data.deleted_low_lying_areas = deleted_objects["sneak_areas"]
+                    if "sneak_areas_end" in deleted_objects:
+                        map_data.deleted_low_lying_areas = deleted_objects["sneak_areas_end"]
                     if "rec_vw" in deleted_objects:
                         map_data.deleted_recommended_area_type = deleted_objects["rec_vw"]  ## TODO: Handle this
 

--- a/custom_components/dreame_vacuum/dreame/types.py
+++ b/custom_components/dreame_vacuum/dreame/types.py
@@ -4523,6 +4523,7 @@ class MapData:
         self.deleted_carpets: Optional[List[Carpet]] = None  # Data json: vw.nocpt
         self.detected_carpets: Optional[List[Carpet]] = None  # Data json: carpet_info
         self.low_lying_areas: Optional[List[Polygon]] = None  # Data json: sneak_areas or sneak_areas_end
+        self.low_lying_area_key: Optional[str] = None  # Data json: sneak_areas or sneak_areas_end
         self.cleaning_sequence: Optional[Dict[int, int]] = None  # Data json: cleanareaorder
         self.mop_type: Optional[Dict[int, str]] = None  # Data json: mop_type_with_order
         self.current_mop_type: Optional[Dict[int, str]] = None  # Data json: moptype


### PR DESCRIPTION
## Summary
- implement low-lying area editing for saved maps
- preserve the map payload key used for low-lying areas
- include saved low-lying area payload fields so creation and deletion persist across map refreshes

## Testing
- python -m py_compile custom_components/dreame_vacuum/dreame/device.py custom_components/dreame_vacuum/dreame/map.py custom_components/dreame_vacuum/dreame/types.py
- git diff --check origin/dev..HEAD
- installed fork build in Home Assistant via HACS
- verified vacuum_set_low_lying_area creation persisted on both camera.todd_map and camera.todd_map_1 after refresh polling
- verified vacuum_set_low_lying_area deletion with an empty area list persisted on both camera.todd_map and camera.todd_map_1 after refresh polling