### PR TITLE
Fix ZeroDivisionError in map.py

### DIFF
--- a/custom_components/dreame_vacuum/dreame/map.py
+++ b/custom_components/dreame_vacuum/dreame/map.py
@@ -7877,8 +7877,9 @@ class DreameVacuumMapRenderer:
         y = y1 - y0
         count = size - 1 if size else math.floor(math.sqrt(x * x + y * y) / spacing)
         points = []
-        for i in range(count + 1):
-            points.append((x0 + x * (i / count), y0 + y * (i / count)))
+        if count > 0:
+            for i in range(count + 1):
+                points.append((x0 + x * (i / count), y0 + y * (i / count)))
         return points
 
     @staticmethod


### PR DESCRIPTION
The map rendering failed on my installation. I got the following error so I added another check to only calculate points if count > 0. After that change the map rendered fine.

File "/config/custom_components/dreame_vacuum/dreame/map.py", line 7881, in _coords_on_line ZeroDivisionError: division by zero