### PR TITLE
Complete German map restore service translations

### DIFF
--- a/custom_components/dreame_vacuum/translations/de.json
+++ b/custom_components/dreame_vacuum/translations/de.json
@@ -687,6 +687,20 @@
         }
       }
     },
+    "vacuum_restore_map": {
+      "name": "Karte wiederherstellen",
+      "description": "Stellt eine Karte wieder her.",
+      "fields": {
+        "map_id": {
+          "name": "Karten-ID",
+          "description": "ID der wiederherzustellenden Karte."
+        },
+        "recovery_map_index": {
+          "name": "Index der Wiederherstellungskarte",
+          "description": "Index der gespeicherten Wiederherstellungskarte."
+        }
+      }
+    },
     "vacuum_restore_map_from_file": {
       "name": "Karte aus Datei wiederherstellen",
       "description": "Stellen Sie eine Karte aus einer Datei wieder her.",


### PR DESCRIPTION
## Summary
- add the six missing German strings for the `vacuum_restore_map` service
- remove the remaining English fallback for this service in a German Home Assistant UI
- keep terminology aligned with the existing German `vacuum_restore_map_from_file` translation

## Validation
- German translation JSON parses successfully
- German and English scalar translation-key paths are now identical
- `git diff --check` passes