### PR TITLE
Add warn status sensor

### DIFF
--- a/custom_components/dreame_vacuum/dreame/device.py
+++ b/custom_components/dreame_vacuum/dreame/device.py
@@ -8581,6 +8581,21 @@ class DreameVacuumDeviceStatus:
         return ERROR_CODE_TO_ERROR_NAME.get(self.error, STATE_UNKNOWN)
 
     @property
+    def warn_status(self) -> DreameVacuumErrorCode:
+        """Return warning status of the device."""
+        value = self._get_property(DreameVacuumProperty.WARN_STATUS)
+        if value is not None and value in DreameVacuumErrorCode._value2member_map_:
+            return DreameVacuumErrorCode(value)
+        if value is not None:
+            _LOGGER.debug("WARN_STATUS not supported: %s", value)
+        return DreameVacuumErrorCode.NO_ERROR
+
+    @property
+    def warn_status_name(self) -> str:
+        """Return warning status as string for translation."""
+        return ERROR_CODE_TO_ERROR_NAME.get(self.warn_status, STATE_UNKNOWN)
+
+    @property
     def error_description(self) -> str:
         """Return error description of the device."""
         return ERROR_CODE_TO_ERROR_DESCRIPTION.get(self.error, [STATE_UNKNOWN, ""])

--- a/custom_components/dreame_vacuum/sensor.py
+++ b/custom_components/dreame_vacuum/sensor.py
@@ -170,6 +170,14 @@ SENSORS: tuple[DreameVacuumSensorEntityDescription, ...] = (
         },
     ),
     DreameVacuumSensorEntityDescription(
+        property_key=DreameVacuumProperty.WARN_STATUS,
+        icon_fn=lambda value, device: (
+            "mdi:alert-outline" if device.status.warn_status.value else "mdi:check-circle-outline"
+        ),
+        attrs_fn=lambda device: {ATTR_VALUE: device.status.warn_status.value},
+        entity_category=EntityCategory.DIAGNOSTIC,
+    ),
+    DreameVacuumSensorEntityDescription(
         property_key=DreameVacuumProperty.CHARGING_STATUS,
         icon="mdi:home-lightning-bolt",
     ),


### PR DESCRIPTION
The WARN_STATUS property (siid 4, piid 35) is already polled, but no entity exposes it. A device can therefore hold a warning there while the error sensor remains no_error.\n\nThis adds a diagnostic sensor following the existing ERROR sensor pattern. The sensor is created only on devices that report the property.\n\nVerified on a Dreame L40s Pro Ultra: WARN_STATUS reported bin_full (101) while the error sensor reported no_error.