### PR TITLE
fix: always initialize Segment.area

### DIFF
--- a/custom_components/dreame_vacuum/dreame/types.py
+++ b/custom_components/dreame_vacuum/dreame/types.py
@@ -3639,6 +3639,7 @@ class Segment(Zone):
         self.cleanset_type = CleansetType.NONE
         self.carpet_cleaning = None
         self.carpet_preferences = None
+        self.area = None
         self.set_name()
         if x1 != None and x0 != None and y1 != None and y0 != None:
             self.area = abs(x1 - x0) * abs(y1 - y0)


### PR DESCRIPTION
## Problem

`Segment.__eq__` dereferences `self.area`, but `Segment.__init__` only assigns it when all four coordinates are supplied:

```python
# dreame/types.py
self.carpet_preferences = None
self.set_name()
if x1 != None and x0 != None and y1 != None and y0 != None:
    self.area = abs(x1 - x0) * abs(y1 - y0)
```

Every other attribute in `__init__` gets an unconditional default. `area` is the only one that can be absent entirely.

`map.py` builds bare segments for unmapped rooms:

```python
# dreame/map.py:4615
target_seg = Segment(seg_id) if is_unmmaped else segments[seg_id]
...
segments[seg_id] = target_seg
target_seg.unmapped = True
```

Those instances have no `area`, so any later comparison raises:

```
AttributeError: 'Segment' object has no attribute 'area'
```

`render_map()` compares whole segment dicts in two places to decide whether it can skip a re-render (`map.py:8951` and `map.py:8988`), so this surfaces as repeated `Map render Failed` and the map stops updating.

## Reproducer

No device and no Home Assistant instance needed — `types.py` imports only from the standard library:

```python
import importlib.util, sys
spec = importlib.util.spec_from_file_location("t", "custom_components/dreame_vacuum/dreame/types.py")
m = importlib.util.module_from_spec(spec); sys.modules["t"] = m; spec.loader.exec_module(m)

{1: m.Segment(1)} == {1: m.Segment(1)}
# AttributeError: 'Segment' object has no attribute 'area'
```

## Fix

Give `area` an unconditional default alongside the other attributes.

## Notes

- `map.py:4603` already guards for this exact case (`segments[seg_id].area if seg_id in segments else 0`), which suggests the omission in `__eq__` is an oversight rather than intent.
- Both the `area` attribute and the unmapped-segment path are new in v2 — v1.0.11 has neither.
- Identical segments still compare equal afterwards, so the render cache is not affected:

| comparison | before | after |
| --- | --- | --- |
| `Segment(1) == Segment(1)` | AttributeError | True |
| `Segment(2, 0, 0, 100, 100) == Segment(2, 0, 0, 100, 100)` | True | True |
| `Segment(2, 0, 0, 100, 100) != Segment(2, 0, 0, 200, 100)` | True | True |
