### PR TITLE
fix: avoid Dreamehome cloud timeout storm on fresh connections

### DIFF
--- a/custom_components/dreame_vacuum/dreame/device.py
+++ b/custom_components/dreame_vacuum/dreame/device.py
@@ -812,10 +812,16 @@ class DreameVacuumDevice:
         props = property_list.copy()
         results = []
         while props:
-            result = self._protocol.get_properties(props[:15], timeout=(10 if len(property_list) > 15 else None))
-            if result is not None:
-                results.extend(result)
-                props[:] = props[15:]
+            # No separate, tighter timeout here anymore - the central value in
+            # protocol.py already covers the ~5s the first request on a new
+            # connection needs.
+            result = self._protocol.get_properties(props[:15])
+            if result is None:
+                # Otherwise this loop spins forever, firing requests against
+                # the cloud without end.
+                break
+            results.extend(result)
+            props[:] = props[15:]
 
         return self._handle_properties(results)
 

--- a/custom_components/dreame_vacuum/dreame/protocol.py
+++ b/custom_components/dreame_vacuum/dreame/protocol.py
@@ -35,6 +35,18 @@ DREAME_STRINGS: Final = (
 
 _LOGGER = logging.getLogger(__name__)
 
+# The Dreame cloud consistently needs ~5s (measured: 4.3-5.2s) to answer the
+# first request on a freshly established connection; follow-up requests on
+# the same connection return in 0.1-0.3s. The previous 6s default was close
+# enough to that first-request latency that occasional timeouts were
+# expected, and each timeout triggered login(), which opened a new
+# connection and repeated the slow first request - a self-sustaining storm
+# of timeouts and re-logins.
+API_TIMEOUT: Final = 20
+LOGIN_TIMEOUT: Final = 20
+LOGIN_BACKOFF_START: Final = 5
+LOGIN_BACKOFF_MAX: Final = 300
+
 
 class DreameVacuumDeviceProtocol(MiIOProtocol):
     def __init__(self, ip: str, token: str) -> None:
@@ -118,6 +130,8 @@ class DreameVacuumDreameHomeCloudProtocol:
         self._connected_callback = None
         self._logged_in = False
         self._auth_failed = False
+        self._login_backoff = 0
+        self._login_blocked_until = None
         self._stream_key = None
         self._client_key = None
         self._secondary_key = auth_key
@@ -337,6 +351,13 @@ class DreameVacuumDreameHomeCloudProtocol:
         return None
 
     def login(self) -> bool:
+        # A failed login must not be retried immediately - each attempt
+        # blocks the next one for a growing interval (capped at
+        # LOGIN_BACKOFF_MAX) instead of opening a new connection right away.
+        if self._login_blocked_until and time.time() < self._login_blocked_until:
+            _LOGGER.debug("Skipping login, retrying in %.0f s", self._login_blocked_until - time.time())
+            return False
+
         self._session.close()
         self._session = requests.session()
 
@@ -375,7 +396,7 @@ class DreameVacuumDreameHomeCloudProtocol:
                 self.get_api_url() + self._strings[17],
                 headers=headers,
                 data=data,
-                timeout=10,
+                timeout=LOGIN_TIMEOUT,
             )
             if response.status_code == 200:
                 data = json.loads(response.text)
@@ -401,7 +422,7 @@ class DreameVacuumDreameHomeCloudProtocol:
         except requests.exceptions.Timeout:
             response = None
             self._logged_in = False
-            _LOGGER.warning("Login Failed: Read timed out. (read timeout=10)")
+            _LOGGER.warning("Login Failed: Read timed out. (read timeout=%s)", LOGIN_TIMEOUT)
         except Exception as ex:
             response = None
             self._logged_in = False
@@ -410,6 +431,15 @@ class DreameVacuumDreameHomeCloudProtocol:
         if self._logged_in:
             self._fail_count = 0
             self._connected = True
+            self._login_backoff = 0
+            self._login_blocked_until = None
+        else:
+            self._login_backoff = min(
+                LOGIN_BACKOFF_MAX,
+                LOGIN_BACKOFF_START if not self._login_backoff else self._login_backoff * 2,
+            )
+            self._login_blocked_until = time.time() + self._login_backoff
+            _LOGGER.debug("Login failed, next attempt in %s s", self._login_backoff)
         return self._logged_in
 
     def get_supported_devices(self, models, host=None, mac=None, device_id=None) -> Any:
@@ -548,9 +578,17 @@ class DreameVacuumDreameHomeCloudProtocol:
         )
 
     def send(self, method, parameters, retry_count: int = 2, timeout=None) -> Any:
-        host = ""
-        if self._host and len(self._host):
-            host = f"-{self._host.split('.')[0]}"
+        # Without a known host the URL below is missing the device-server
+        # prefix and the cloud answers with 404 instead of routing the
+        # request - fetch it once instead of sending a request we know
+        # will fail.
+        if not self._host:
+            self.get_device_info()
+            if not self._host:
+                _LOGGER.warning("Cannot send %s: device host is unknown", method)
+                return None
+
+        host = f"-{self._host.split('.')[0]}"
 
         api_response = self._api_call(
             f"{self._strings[37]}{host}/{self._strings[27]}/{self._strings[38]}",
@@ -724,15 +762,24 @@ class DreameVacuumDreameHomeCloudProtocol:
     def request(self, url: str, data, retry_count=2, timeout=None) -> Any:
         retries = 0
         if not timeout:
-            timeout = 6
+            timeout = API_TIMEOUT
 
         if self._key_expire and time.time() > self._key_expire:
+            if not self.login():
+                return None
+
+        # Without a token every request fails with 401, which in turn
+        # triggers a login - log in once up front instead of running that
+        # loop.
+        if not self._key:
             if not self.login():
                 return None
 
         if not retry_count or retry_count < 0:
             retry_count = 0
         while retries < retry_count + 1:
+            if retries:
+                sleep(min(2 ** (retries - 1), 8))
             try:
                 headers = {
                     "Accept": "*/*",
@@ -754,12 +801,18 @@ class DreameVacuumDreameHomeCloudProtocol:
                 retries = retries + 1
                 response = None
                 if self._connected:
-                    _LOGGER.warning(f"Error while executing request: Read timed out. (timeout={timeout})")
+                    _LOGGER.warning(
+                        "Error while executing request: Read timed out. (timeout=%s, url=%s, attempt %s/%s)",
+                        timeout,
+                        url,
+                        retries,
+                        retry_count + 1,
+                    )
             except Exception as ex:
                 retries = retries + 1
                 response = None
                 if self._connected:
-                    _LOGGER.warning("Error while executing request: %s", str(ex))
+                    _LOGGER.warning("Error while executing request to %s: %s", url, str(ex))
 
         if response is not None:
             if response.status_code == 200:
@@ -767,10 +820,10 @@ class DreameVacuumDreameHomeCloudProtocol:
                 self._connected = True
                 return json.loads(response.text)
             elif response.status_code == 401 and self._secondary_key:
-                _LOGGER.warning("Execute api call failed: Token Expired")
+                _LOGGER.warning("Execute api call failed: Token Expired (%s)", url)
                 self.login()
             else:
-                _LOGGER.warning("Execute api call failed with response: %s", response.text)
+                _LOGGER.warning("Execute api call to %s failed with response: %s", url, response.text)
 
         if self._fail_count == 5:
             self._connected = False


### PR DESCRIPTION
## What

`DreameVacuumDreameHomeCloudProtocol` (Dreamehome cloud, EU region) can get
stuck in a self-sustaining timeout/re-login storm right after setup, with
config entry setup failing repeatedly as "Unable to discover the device
over cloud". This is very likely the underlying cause of #1725 and part of
what #1500 described (the retry loop itself was already discussed there;
this PR is about why the retries were needed in the first place).

## Root cause

Measured directly against the cloud endpoint from inside the HA container
(DNS, TCP/TLS handshake, and `sendCommand` with 1-30 properties, each
timed separately):

| Check | Result |
|---|---|
| DNS `eu.iot.dreame.tech` | ~20ms |
| TCP + TLS to all 5 round-robin IPs | 20-50ms |
| `sendCommand`, first call on a fresh connection | **4.3-5.2s** |
| `sendCommand`, follow-up calls on the same connection | 0.1-0.3s |

The cloud itself is healthy - DNS/TCP/TLS are fast, and the device reports
`online: True` with the correct local IP throughout. The first request over
a newly established connection is just consistently slow (~5s), and
`request()`'s 6s default timeout was close enough to that latency that it
tipped over regularly. Every timeout was treated as a reason to `login()`
again, which opened a fresh connection and hit the same ~5s first-request
latency - producing a loop of timeouts and re-logins that never recovered
on its own. Log evidence: every timeout logged `timeout=6` / `timeout=10`,
with the request thread number climbing rapidly between retries.

## Changes

- `protocol.py`: raise `request()`/`login()` timeouts from 6s/10s to a
  shared 20s constant, comfortably above the measured worst case.
- `protocol.py`: exponential backoff on `login()` (5s, doubling, capped at
  300s) so a failing login stops hammering the cloud instead of retrying
  instantly.
- `protocol.py`: `request()` logs in once up front if no token is held
  yet, instead of letting the first real request fail with 401 and
  triggering a login from inside the error path.
- `protocol.py`: `send()` fetches device info once if the device host is
  still unknown, instead of sending a request to a URL that's missing the
  device-server prefix and is guaranteed to 404.
- `protocol.py`: wait between retries (1/2/4/8s) instead of retrying
  immediately.
- `protocol.py`: error logs now include the request URL and attempt
  count - this was the main thing that made the storm hard to diagnose
  from a user-supplied log, since every line looked identical.
- `device.py`: `_request_properties()` no longer overrides the timeout
  with its own tighter one (redundant now that the central timeout covers
  it) and breaks out of its batch loop when a request returns nothing,
  instead of spinning forever and firing requests at the cloud without
  end.

This is additive to the polling-interval backoff already in `device.py`
(the 5s/10s/30s-since-last-failure logic) - that one paces *scheduled*
updates, this one fixes the *connection-level* timeout/login behavior
underneath it.

## Testing

Reproduced and fixed on a Dreame L10s Ultra Gen 2 (`dreame.vacuum.r2469a`)
via a Dreamehome account, EU region. Before the fix: a timeout roughly
every 1-2 minutes, and a continuous storm during initial setup. After:
observed for several minutes post-restart with zero timeout log entries;
the vacuum entity reports state correctly and the map/room entities update
as expected.
