### PR TITLE
Poll water tank status until warnings clear

### DIFF
--- a/custom_components/dreame_vacuum/dreame/device.py
+++ b/custom_components/dreame_vacuum/dreame/device.py
@@ -340,6 +340,7 @@ class DreameVacuumDevice:
         self._ready: bool = False
         # Last settings properties requested time
         self._last_settings_request: float = 0
+        self._last_water_tank_status_request: float = 0
         self._last_map_list_request: float = 0  # Last map list property requested time
         self._last_map_request: float = 0  # Last map request trigger time
         self._last_change: float = 0  # Last property change time
@@ -3403,6 +3404,17 @@ class DreameVacuumDevice:
             properties.extend([DreameVacuumProperty.MAP_LIST, DreameVacuumProperty.RECOVERY_MAP_LIST])
             self._last_map_list_request = time.time()
 
+        clean_water_tank_status = self.get_property(DreameVacuumProperty.CLEAN_WATER_TANK_STATUS)
+        water_tank_status_properties = None
+        if self.status.low_water or clean_water_tank_status in (
+            DreameVacuumCleanWaterTankStatus.NOT_INSTALLED.value,
+            DreameVacuumCleanWaterTankStatus.LOW_WATER.value,
+        ):
+            water_tank_status_properties = [
+                DreameVacuumProperty.LOW_WATER_WARNING,
+                DreameVacuumProperty.CLEAN_WATER_TANK_STATUS,
+            ]
+
         if (
             self._protocol.dreame_cloud
             and self.device_connected
@@ -3436,6 +3448,8 @@ class DreameVacuumDevice:
                 DreameVacuumProperty.ERROR,
                 DreameVacuumProperty.FAULTS,
             ]
+            if water_tank_status_properties:
+                properties.extend(water_tank_status_properties)
 
         try:
             if self._protocol.dreame_cloud and (not self.device_connected or not self.cloud_connected):
@@ -3447,6 +3461,10 @@ class DreameVacuumDevice:
                 self._request_properties([DreameVacuumProperty.MAP_BACKUP_STATUS])
             elif self.status.map_recovery_status:
                 self._request_properties([DreameVacuumProperty.MAP_RECOVERY_STATUS])
+            elif water_tank_status_properties and now - self._last_water_tank_status_request >= 30:
+                # Dreame Cloud does not always push the cleared status after a tank is refilled.
+                self._last_water_tank_status_request = now
+                self._request_properties(water_tank_status_properties)
         except Exception as ex:
             raise DeviceUpdateFailedException(ex) from None
 

--- a/tests/test_water_status_polling.py
+++ b/tests/test_water_status_polling.py
@@ -1,0 +1,66 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from custom_components.dreame_vacuum.dreame.device import DreameVacuumDevice
+from custom_components.dreame_vacuum.dreame.types import (
+    DreameVacuumCleanWaterTankStatus,
+    DreameVacuumProperty,
+)
+
+
+def _cloud_device(*, clean_water_status: int, low_water: bool) -> DreameVacuumDevice:
+    device = DreameVacuumDevice("Test vacuum", None, None)
+    device._protocol = SimpleNamespace(
+        cloud=SimpleNamespace(connected=True),
+        connected=True,
+        dreame_cloud=True,
+        prefer_cloud=True,
+    )
+    device.capability = SimpleNamespace(backup_map=False)
+    device.status = SimpleNamespace(
+        active=False,
+        low_water=low_water,
+        map_backup_status=False,
+        map_recovery_status=False,
+        started=False,
+        washing=False,
+    )
+    device.data[DreameVacuumProperty.CLEAN_WATER_TANK_STATUS.value] = clean_water_status
+    device._last_settings_request = float("inf")
+    device._map_manager = None
+    device._dirty_data = {}
+    device._dirty_auto_switch_data = {}
+    device._dirty_ai_data = {}
+    device._consumable_change = False
+    device._draining_complete_time = None
+    device._request_properties = Mock()
+    device._request_cleaning_history = Mock()
+    return device
+
+
+def test_cloud_water_status_is_polled_while_low() -> None:
+    device = _cloud_device(
+        clean_water_status=DreameVacuumCleanWaterTankStatus.LOW_WATER.value,
+        low_water=True,
+    )
+
+    device.update()
+    device.update()
+
+    device._request_properties.assert_called_once_with(
+        [
+            DreameVacuumProperty.LOW_WATER_WARNING,
+            DreameVacuumProperty.CLEAN_WATER_TANK_STATUS,
+        ]
+    )
+
+
+def test_cloud_water_status_is_not_polled_after_refill() -> None:
+    device = _cloud_device(
+        clean_water_status=DreameVacuumCleanWaterTankStatus.INSTALLED.value,
+        low_water=False,
+    )
+
+    device.update()
+
+    device._request_properties.assert_not_called()


### PR DESCRIPTION
## Summary

- Poll `LOW_WATER_WARNING` and `CLEAN_WATER_TANK_STATUS` while either cached value still reports an abnormal clean-water state.
- Reuse the existing active-state property request; otherwise limit reconciliation to one request every 30 seconds.
- Stop the extra polling as soon as both values are normal.

Dreame Cloud normally pushes property changes, but it can miss the cleared state after an Aqua10 Ultra Roller clean-water tank is refilled. Home Assistant then keeps the warning until the integration is reloaded.

This complements the dismissed-warning decoding correction added in b23. It only provides a bounded fallback when the cloud has genuinely left an abnormal value cached, matching the stale-state behaviour reported in #633.

## Testing

- `pytest -q tests/test_water_status_polling.py`: 2 passed
- Home Assistant hassfest: 1 valid integration, 0 invalid integrations
- HACS validation against this exact fork branch: all 4 checks passed
- Home Assistant OS, Core 2026.8.3, integration b25 plus this patch:
  - all five Dreame config entries loaded after restart
  - Aqua10 clean tank returned to `installed` 8.49 seconds after removal/reinsertion
  - dirty tank returned to `installed` in about 6 seconds during the same smoke test
  - low-water warning remained `no_warning`