### PR TITLE
fix: tear down device resources on failed setup and update retries (memory/thread leak, #1762)

### DIFF
--- a/custom_components/dreame_vacuum/__init__.py
+++ b/custom_components/dreame_vacuum/__init__.py
@@ -5,6 +5,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.components.frontend import DATA_EXTRA_MODULE_URL
+import logging
 import warnings
 from pathlib import Path
 from .const import DOMAIN
@@ -34,10 +35,40 @@ PLATFORMS = (
 )
 
 
+_LOGGER = logging.getLogger(__name__)
+
+
+async def _teardown_coordinator(coordinator) -> None:
+    """Stop the device of a coordinator that is never going to be used.
+
+    A failed first refresh (cloud discovery failure, auth failure, or setup
+    cancellation after Home Assistant's setup timeout) otherwise leaves the
+    device running with its worker threads, timers and cloud connections.
+    Home Assistant retries setup every ~30 s, so every retry used to leak the
+    previous attempt's resources until Home Assistant ran out of memory
+    (see https://github.com/Tasshack/dreame-vacuum/issues/1762).
+    """
+    device = getattr(coordinator, "_device", None)
+    if device is None:
+        return
+    device.listen(None)
+    device.listen_error(None)
+    try:
+        device.disconnect()
+    except Exception:
+        _LOGGER.exception("Error while disconnecting device after failed setup")
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Dreame Vacuum from a config entry."""
     coordinator = DreameVacuumDataUpdateCoordinator(hass, entry=entry)
-    await coordinator.async_config_entry_first_refresh()
+    # Cleanup must cover BaseException: Home Assistant cancels slow setups with
+    # CancelledError, which does not derive from Exception.
+    try:
+        await coordinator.async_config_entry_first_refresh()
+    except BaseException:
+        await _teardown_coordinator(coordinator)
+        raise
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
 

--- a/custom_components/dreame_vacuum/coordinator.py
+++ b/custom_components/dreame_vacuum/coordinator.py
@@ -517,21 +517,34 @@ class DreameVacuumDataUpdateCoordinator(DataUpdateCoordinator[DreameVacuumDevice
                 self._device.schedule_update()
                 self.async_set_updated_data()
                 return self._device
-        except Exception as ex:
-            if self._device.auth_failed:
-                raise ConfigEntryAuthFailed("Authentication Failed!") from ex
-
+        except BaseException as ex:
+            # Teardown must run for every failure, including CancelledError raised
+            # when Home Assistant cancels a slow setup after its timeout. Without
+            # this, every setup retry leaks the previous device together with its
+            # worker threads and cloud sessions until Home Assistant runs out of
+            # memory (https://github.com/Tasshack/dreame-vacuum/issues/1762).
             LOGGER.warning("Integration start failed: %s", traceback.format_exc())
+            auth_failed = False
             if self._device is not None:
+                auth_failed = self._device.auth_failed
                 self._device.listen(None)
                 self._device.listen_error(None)
-                self._device.disconnect()
+                try:
+                    self._device.disconnect()
+                except Exception:
+                    LOGGER.exception("Error while disconnecting device after failed start")
                 del self._device
                 self._device = None
-                
+
             if self._unsub_dispatcher:
                 self._unsub_dispatcher()
                 self._unsub_dispatcher = None
+
+            if not isinstance(ex, Exception):
+                raise  # propagate CancelledError / KeyboardInterrupt untouched
+
+            if auth_failed:
+                raise ConfigEntryAuthFailed("Authentication Failed!") from ex
 
             raise UpdateFailed(ex) from ex
 


### PR DESCRIPTION
## Problem

When the first refresh fails (e.g. `Unable to discover the device over cloud`), the coordinator created in `async_setup_entry` is orphaned **with its device, worker threads, timers and cloud sessions still running**. Home Assistant retries setup every ~30 s, so every retry leaks the previous attempt's resources until Home Assistant runs out of memory and stops responding.

This is the mechanism behind a growing family of reports (#1762, #1759, #1650, #1664, #1361, #1350, #1746): users consistently observe `Thread-N` identifiers from `dreame_vacuum.dreame.device/.map/.protocol` climbing into the thousands alongside steadily rising RAM.

## Root cause

Two failure paths never call the existing `DreameDevice.disconnect()` teardown:

1. **`async_setup_entry`**: `async_config_entry_first_refresh()` failing raises straight through the function; setup retries then construct an entirely fresh coordinator/device each time. A `supports_unload=false` entry that never loaded has no other cleanup path.
2. **`coordinator.py::_async_update_data`**: the `except` block raises `ConfigEntryAuthFailed` **before** its cleanup lines in the auth-failure branch, and handles `except Exception` — which lets `CancelledError` (raised when Home Assistant cancels a slow setup after its timeout) bypass the teardown entirely.

## Changes

1. **`async_setup_entry`**: on *any* first-refresh failure, tear down the orphaned coordinator's device (`listen(None)`, `listen_error(None)`, `disconnect()`) and re-raise. The cleanup covers `BaseException` because Home Assistant cancels slow setups with `CancelledError`, which does not derive from `Exception`.
2. **`coordinator._async_update_data`**: teardown now always runs before raising (`disconnect()` itself is guarded so a teardown error cannot mask the original error), the early `ConfigEntryAuthFailed` raise happens *after* cleanup instead of before it, and `CancelledError`/`KeyboardInterrupt` propagate instead of being wrapped in `UpdateFailed`.

`DreameDevice.disconnect()` already cancels the keep-alive/update/callback timers and disconnects the protocol session, so no protocol-level changes are needed for this fix.

## Testing

- `py_compile` on both files.
- Observed behavior with `v2.0.0b25` on HA 2026.8.3 before the change: repeated `Unable to discover the device over cloud` during setup retries leaks one device (protocol/MQTT worker threads + sessions) per retry; after the patch the failure path disconnects the device before re-raising.
- Suggested verification for reviewers/maintainers: enable the integration while the device is unreachable and watch `threading.active_count()`/RSS stay flat across setup retries instead of climbing.

Fixes #1762. Related: #1759, #1650, #1664, #1361, #1350.