### PR TITLE
Use translation keys for entity names

### DIFF
--- a/custom_components/dreame_vacuum/entity.py
+++ b/custom_components/dreame_vacuum/entity.py
@@ -165,8 +165,6 @@ class DreameVacuumEntity(CoordinatorEntity[DreameVacuumDataUpdateCoordinator]):
             if self.entity_description.icon_fn is not None:
                 self._attr_icon = self.entity_description.icon_fn(self.native_value, self.device)
 
-            self._attr_name = self.entity_description.name
-
     def _generate_entity_id(self, format) -> None:
         if self.entity_description.key:
             self.entity_id = async_generate_entity_id(

--- a/custom_components/dreame_vacuum/strings.json
+++ b/custom_components/dreame_vacuum/strings.json
@@ -582,6 +582,12 @@
           "three_seat_sofa_narrow": "Three-Seat sofa narrow",
           "l_shaped_sofa_right": "L-Shaped sofa right"
         }
+      },
+      "map_rotation": {
+        "name": "Map Rotation"
+      },
+      "selected_map": {
+        "name": "Selected Map"
       }
     },
     "sensor": {
@@ -1301,6 +1307,99 @@
       },
       "wheel_dirty_left": {
         "name": "Wheel Cleaning"
+      },
+      "battery_level": {
+        "name": "Battery Level"
+      },
+      "cleaned_area": {
+        "name": "Cleaned Area"
+      },
+      "cleaning_count": {
+        "name": "Cleaning Count"
+      },
+      "cleaning_history": {
+        "name": "Cleaning History"
+      },
+      "cleaning_progress": {
+        "name": "Cleaning Progress"
+      },
+      "cleaning_time": {
+        "name": "Cleaning Time"
+      },
+      "cruising_history": {
+        "name": "Cruising History"
+      },
+      "current_room": {
+        "name": "Current Room"
+      },
+      "deodorizer_time_left": {
+        "name": "Deodorizer Time Left"
+      },
+      "detergent_time_left": {
+        "name": "Detergent Time Left"
+      },
+      "drying_left": {
+        "name": "Drying Left"
+      },
+      "drying_progress": {
+        "name": "Drying Progress"
+      },
+      "dust_bag_drying_left": {
+        "name": "Dust Bag Drying Left"
+      },
+      "filter_time_left": {
+        "name": "Filter Time Left"
+      },
+      "first_cleaning_date": {
+        "name": "First Cleaning Date"
+      },
+      "fluffing_roller_dirty_time_left": {
+        "name": "Fluffing Roller Dirty Time Left"
+      },
+      "main_brush_time_left": {
+        "name": "Main Brush Time Left"
+      },
+      "mapping_time": {
+        "name": "Mapping Time"
+      },
+      "mop_pad_time_left": {
+        "name": "Mop Pad Time Left"
+      },
+      "onboard_dirty_water_tank_time_left": {
+        "name": "Onboard Dirty Water Tank Time Left"
+      },
+      "roller_mop_filter_dirty_time_left": {
+        "name": "Roller Mop Filter Dirty Time Left"
+      },
+      "scale_inhibitor_time_left": {
+        "name": "Scale Inhibitor Time Left"
+      },
+      "sensor_dirty_time_left": {
+        "name": "Sensor Dirty Time Left"
+      },
+      "side_brush_time_left": {
+        "name": "Side Brush Time Left"
+      },
+      "silver_ion_time_left": {
+        "name": "Silver-ion Time Left"
+      },
+      "squeegee_time_left": {
+        "name": "Squeegee Time Left"
+      },
+      "tank_filter_time_left": {
+        "name": "Tank Filter Time Left"
+      },
+      "total_cleaned_area": {
+        "name": "Total Cleaned Area"
+      },
+      "total_cleaning_time": {
+        "name": "Total Cleaning Time"
+      },
+      "water_outlet_filter_dirty_time_left": {
+        "name": "Water Outlet Filter Dirty Time Left"
+      },
+      "wheel_dirty_time_left": {
+        "name": "Wheel Dirty Time Left"
       }
     },
     "switch": {
@@ -1456,6 +1555,178 @@
       },
       "dnd": {
         "name": "DnD"
+      },
+      "ai_fluid_detection": {
+        "name": "AI Fluid Detection"
+      },
+      "ai_furniture_detection": {
+        "name": "AI Furniture Detection"
+      },
+      "ai_human_detection": {
+        "name": "AI Human Detection"
+      },
+      "ai_obstacle_image_upload": {
+        "name": "AI Obstacle Image Upload"
+      },
+      "ai_pet_avoidance": {
+        "name": "AI Pet Avoidance"
+      },
+      "auto_charging": {
+        "name": "Auto Charging"
+      },
+      "auto_water_refilling": {
+        "name": "Auto Water Refilling"
+      },
+      "camera_light_brightness_auto": {
+        "name": "Camera Light Brightness Auto"
+      },
+      "cleaning_sequence": {
+        "name": "Cleaning Sequence"
+      },
+      "dust_bag_drying": {
+        "name": "Dust Bag Drying"
+      },
+      "fuzzy_obstacle_detection": {
+        "name": "Fuzzy Obstacle Detection"
+      },
+      "human_follow": {
+        "name": "Human Follow"
+      },
+      "lds_state": {
+        "name": "LDS State"
+      },
+      "max_suction_power": {
+        "name": "Max Suction Power"
+      },
+      "mop_extend": {
+        "name": "Mop Extend"
+      },
+      "pet_picture": {
+        "name": "Pet Picture"
+      },
+      "self_clean_by_zone": {
+        "name": "Self Clean By Zone"
+      },
+      "side_reach": {
+        "name": "Side Reach"
+      },
+      "smart_drying": {
+        "name": "Smart Drying"
+      },
+      "stain_avoidance": {
+        "name": "Stain Avoidance"
+      },
+      "tight_mopping": {
+        "name": "Tight Mopping"
+      },
+      "ultra_clean_mode": {
+        "name": "Ultra Clean Mode"
+      },
+      "water_electrolysis": {
+        "name": "Water Electrolysis"
+      }
+    },
+    "button": {
+      "backup_saved_map": {
+        "name": "Backup Saved Map"
+      },
+      "base_station_cleaning": {
+        "name": "Base Station Cleaning"
+      },
+      "base_station_self_repair": {
+        "name": "Base Station Self Repair"
+      },
+      "clear_warning": {
+        "name": "Clear Warning"
+      },
+      "empty_water_tank": {
+        "name": "Empty Water Tank"
+      },
+      "manual_drying": {
+        "name": "Manual Drying"
+      },
+      "manual_dust_bag_drying": {
+        "name": "Manual Dust Bag Drying"
+      },
+      "reload_shortcuts": {
+        "name": "Reload Shortcuts"
+      },
+      "reset_deodorizer": {
+        "name": "Reset Deodorizer"
+      },
+      "reset_detergent": {
+        "name": "Reset Detergent"
+      },
+      "reset_dirty_water_channel": {
+        "name": "Reset Dirty Water Channel"
+      },
+      "reset_filter": {
+        "name": "Reset Filter"
+      },
+      "reset_fluffing_roller": {
+        "name": "Reset Fluffing Roller"
+      },
+      "reset_main_brush": {
+        "name": "Reset Main Brush"
+      },
+      "reset_mop_pad": {
+        "name": "Reset Mop Pad"
+      },
+      "reset_onboard_dirty_water_tank": {
+        "name": "Reset Onboard Dirty Water Tank"
+      },
+      "reset_roller_mop_filter": {
+        "name": "Reset Roller Mop Filter"
+      },
+      "reset_scale_inhibitor": {
+        "name": "Reset Scale Inhibitor"
+      },
+      "reset_sensor": {
+        "name": "Reset Sensor"
+      },
+      "reset_side_brush": {
+        "name": "Reset Side Brush"
+      },
+      "reset_silver_ion": {
+        "name": "Reset Silver-ion"
+      },
+      "reset_squeegee": {
+        "name": "Reset Squeegee"
+      },
+      "reset_water_outlet_filter": {
+        "name": "Reset Water Outlet Filter"
+      },
+      "reset_wheel": {
+        "name": "Reset Wheel"
+      },
+      "self_clean": {
+        "name": "Self Clean"
+      },
+      "start_auto_empty": {
+        "name": "Start Auto Empty"
+      },
+      "start_fast_mapping": {
+        "name": "Start Fast Mapping"
+      },
+      "start_mapping": {
+        "name": "Start Mapping"
+      },
+      "start_recleaning": {
+        "name": "Start Re-Cleaning"
+      },
+      "water_tank_draining": {
+        "name": "Water Tank Draining"
+      }
+    },
+    "binary_sensor": {
+      "charging_state": {
+        "name": "Charging State"
+      },
+      "lds_status": {
+        "name": "LDS Status"
+      },
+      "roller_cover_status": {
+        "name": "Roller Cover Status"
       }
     },
     "toggle": {
@@ -1496,6 +1767,12 @@
       },
       "volume": {
         "name": "Volume"
+      },
+      "camera_light_brightness": {
+        "name": "Camera Light Brightness"
+      },
+      "mop_cleaning_remainder": {
+        "name": "Mop Cleaning Remainder"
       }
     },
     "time": {

--- a/custom_components/dreame_vacuum/strings.json
+++ b/custom_components/dreame_vacuum/strings.json
@@ -345,7 +345,7 @@
         }
       },
       "cleangenius": {
-        "name": "Cleangenius",
+        "name": "CleanGenius",
         "state": {
           "off": "Off",
           "routine_cleaning": "Routine cleaning",
@@ -353,7 +353,7 @@
         }
       },
       "cleangenius_mode": {
-        "name": "Cleangenius Mode",
+        "name": "CleanGenius Mode",
         "state": {
           "vacuum_and_mop": "Vacuum and Mop",
           "mop_after_vacuum": "Mop after Vacuum"
@@ -929,7 +929,7 @@
         }
       },
       "self_wash_base_status": {
-        "name": "Self Wash Base Status",
+        "name": "Self-Wash Base Status",
         "state": {
           "unknown": "Unknown",
           "idle": "Idle",
@@ -1303,15 +1303,9 @@
         "name": "Wheel Cleaning"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Customized Cleaning"
-      },
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Deep Cleaning"
       },
       "auto_dust_collecting": {
         "name": "Auto-Empty"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Self-Clean"
-      },
-      "deep_mop_washing": {
-        "name": "Deep Mop Washing"
       },
       "hot_washing": {
         "name": "Hot Washing"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV Sterilization"
       },
-      "customized_carpet_cleaning": {
-        "name": "Customized Cleaning"
-      },
       "carpet_avoidance": {
         "name": "Carpet Avoidance"
-      },
-      "carpet_preferences": {
-        "name": "Customized Preferences"
       },
       "auto_change_mop": {
         "name": "Auto Mop Changing"
@@ -1398,13 +1383,10 @@
         "name": "Mop-Washing With Detergent"
       },
       "auto_add_detergent": {
-        "name": "Auto Add Detergent"
+        "name": "Auto-Add Detergent"
       },
       "smart_mop_washing": {
         "name": "Smart Mop Washing"
-      },
-      "wider_corner_coverage": {
-        "name": "Wider Corner Coverage"
       },
       "pressurized_cleaning": {
         "name": "Pressurized Cleaning"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "DnD"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Deep Cleaning"
+      },
+      "deep_mop_washing": {
+        "name": "Deep Mop Washing"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Customized Cleaning"
+      },
+      "carpet_preferences": {
+        "name": "Customized Preferences"
+      },
+      "wider_corner_coverage": {
+        "name": "Wider Corner Coverage"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/strings.json
+++ b/custom_components/dreame_vacuum/strings.json
@@ -1406,6 +1406,12 @@
       "customized_cleaning": {
         "name": "Customized Cleaning"
       },
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Deep Cleaning"
+      },
       "auto_dust_collecting": {
         "name": "Auto-Empty"
       },
@@ -1414,6 +1420,9 @@
       },
       "self_clean": {
         "name": "Self-Clean"
+      },
+      "deep_mop_washing": {
+        "name": "Deep Mop Washing"
       },
       "hot_washing": {
         "name": "Hot Washing"
@@ -1427,8 +1436,14 @@
       "uv_sterilization": {
         "name": "UV Sterilization"
       },
+      "customized_carpet_cleaning": {
+        "name": "Customized Cleaning"
+      },
       "carpet_avoidance": {
         "name": "Carpet Avoidance"
+      },
+      "carpet_preferences": {
+        "name": "Customized Preferences"
       },
       "auto_change_mop": {
         "name": "Auto Mop Changing"
@@ -1486,6 +1501,9 @@
       },
       "smart_mop_washing": {
         "name": "Smart Mop Washing"
+      },
+      "wider_corner_coverage": {
+        "name": "Wider Corner Coverage"
       },
       "pressurized_cleaning": {
         "name": "Pressurized Cleaning"
@@ -1727,26 +1745,6 @@
       },
       "roller_cover_status": {
         "name": "Roller Cover Status"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Deep Cleaning"
-      },
-      "deep_mop_washing": {
-        "name": "Deep Mop Washing"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Customized Cleaning"
-      },
-      "carpet_preferences": {
-        "name": "Customized Preferences"
-      },
-      "wider_corner_coverage": {
-        "name": "Wider Corner Coverage"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/ar.json
+++ b/custom_components/dreame_vacuum/translations/ar.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "تنظيف مخصص"
       },
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "تنظيف عميق"
+      },
       "auto_dust_collecting": {
         "name": "تفريغ تلقائي"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "تنظيف ذاتي"
+      },
+      "deep_mop_washing": {
+        "name": "غسيل عميق للممسحة"
       },
       "hot_washing": {
         "name": "غسيل بالماء الساخن"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "تعقيم بالأشعة فوق البنفسجية"
       },
+      "customized_carpet_cleaning": {
+        "name": "تنظيف مخصص"
+      },
       "carpet_avoidance": {
         "name": "تجنب السجاد"
+      },
+      "carpet_preferences": {
+        "name": "تفضيلات مخصصة"
       },
       "auto_change_mop": {
         "name": "تغيير الممسحة التلقائي"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "غسل ذكي للممسحة"
+      },
+      "wider_corner_coverage": {
+        "name": "تغطية أوسع للزوايا"
       },
       "pressurized_cleaning": {
         "name": "تنظيف بالضغط"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "عدم الإزعاج"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "تنظيف عميق"
-      },
-      "deep_mop_washing": {
-        "name": "غسيل عميق للممسحة"
-      },
-      "customized_carpet_cleaning": {
-        "name": "تنظيف مخصص"
-      },
-      "carpet_preferences": {
-        "name": "تفضيلات مخصصة"
-      },
-      "wider_corner_coverage": {
-        "name": "تغطية أوسع للزوايا"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/ar.json
+++ b/custom_components/dreame_vacuum/translations/ar.json
@@ -1303,15 +1303,9 @@
         "name": "تنظيف العجلات"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "تنظيف مخصص"
-      },
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "تنظيف عميق"
       },
       "auto_dust_collecting": {
         "name": "تفريغ تلقائي"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "تنظيف ذاتي"
-      },
-      "deep_mop_washing": {
-        "name": "غسيل عميق للممسحة"
       },
       "hot_washing": {
         "name": "غسيل بالماء الساخن"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "تعقيم بالأشعة فوق البنفسجية"
       },
-      "customized_carpet_cleaning": {
-        "name": "تنظيف مخصص"
-      },
       "carpet_avoidance": {
         "name": "تجنب السجاد"
-      },
-      "carpet_preferences": {
-        "name": "تفضيلات مخصصة"
       },
       "auto_change_mop": {
         "name": "تغيير الممسحة التلقائي"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "غسل ذكي للممسحة"
-      },
-      "wider_corner_coverage": {
-        "name": "تغطية أوسع للزوايا"
       },
       "pressurized_cleaning": {
         "name": "تنظيف بالضغط"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "عدم الإزعاج"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "تنظيف عميق"
+      },
+      "deep_mop_washing": {
+        "name": "غسيل عميق للممسحة"
+      },
+      "customized_carpet_cleaning": {
+        "name": "تنظيف مخصص"
+      },
+      "carpet_preferences": {
+        "name": "تفضيلات مخصصة"
+      },
+      "wider_corner_coverage": {
+        "name": "تغطية أوسع للزوايا"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/bg.json
+++ b/custom_components/dreame_vacuum/translations/bg.json
@@ -1303,15 +1303,9 @@
         "name": "Почистване на колелата"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Персонализирано почистване"
-      },
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Дълбоко почистване"
       },
       "auto_dust_collecting": {
         "name": "Автоматично изпразване"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Самопочистване"
-      },
-      "deep_mop_washing": {
-        "name": "Дълбоко изпиране на мопа"
       },
       "hot_washing": {
         "name": "Измиване с гореща вода"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV стерилизация"
       },
-      "customized_carpet_cleaning": {
-        "name": "Персонализирано почистване на килими"
-      },
       "carpet_avoidance": {
         "name": "Избягване на килими"
-      },
-      "carpet_preferences": {
-        "name": "Персонализирани предпочитания"
       },
       "auto_change_mop": {
         "name": "Автоматична смяна на мопа"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Умно измиване на мопа"
-      },
-      "wider_corner_coverage": {
-        "name": "По-широко покритие на ъглите"
       },
       "pressurized_cleaning": {
         "name": "Почистване под налягане"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "Не ме безпокойте"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Дълбоко почистване"
+      },
+      "deep_mop_washing": {
+        "name": "Дълбоко изпиране на мопа"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Персонализирано почистване на килими"
+      },
+      "carpet_preferences": {
+        "name": "Персонализирани предпочитания"
+      },
+      "wider_corner_coverage": {
+        "name": "По-широко покритие на ъглите"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/bg.json
+++ b/custom_components/dreame_vacuum/translations/bg.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Персонализирано почистване"
       },
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Дълбоко почистване"
+      },
       "auto_dust_collecting": {
         "name": "Автоматично изпразване"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Самопочистване"
+      },
+      "deep_mop_washing": {
+        "name": "Дълбоко изпиране на мопа"
       },
       "hot_washing": {
         "name": "Измиване с гореща вода"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV стерилизация"
       },
+      "customized_carpet_cleaning": {
+        "name": "Персонализирано почистване на килими"
+      },
       "carpet_avoidance": {
         "name": "Избягване на килими"
+      },
+      "carpet_preferences": {
+        "name": "Персонализирани предпочитания"
       },
       "auto_change_mop": {
         "name": "Автоматична смяна на мопа"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Умно измиване на мопа"
+      },
+      "wider_corner_coverage": {
+        "name": "По-широко покритие на ъглите"
       },
       "pressurized_cleaning": {
         "name": "Почистване под налягане"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "Не ме безпокойте"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Дълбоко почистване"
-      },
-      "deep_mop_washing": {
-        "name": "Дълбоко изпиране на мопа"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Персонализирано почистване на килими"
-      },
-      "carpet_preferences": {
-        "name": "Персонализирани предпочитания"
-      },
-      "wider_corner_coverage": {
-        "name": "По-широко покритие на ъглите"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/ca.json
+++ b/custom_components/dreame_vacuum/translations/ca.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Neteja personalitzada"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Neteja profunda"
+      },
       "auto_dust_collecting": {
         "name": "Buidat automàtic"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Autoneteja"
+      },
+      "deep_mop_washing": {
+        "name": "Rentat profund de mopa"
       },
       "hot_washing": {
         "name": "Rentat amb aigua calenta"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "Esterilització UV"
       },
+      "customized_carpet_cleaning": {
+        "name": "Neteja personalitzada"
+      },
       "carpet_avoidance": {
         "name": "Evitar catifes"
+      },
+      "carpet_preferences": {
+        "name": "Preferències personalitzades"
       },
       "auto_change_mop": {
         "name": "Canvi automàtic de mopa"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Rentat intel·ligent de mopa"
+      },
+      "wider_corner_coverage": {
+        "name": "Major cobertura de racons"
       },
       "pressurized_cleaning": {
         "name": "Neteja pressuritzada"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "DnD"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Neteja profunda"
-      },
-      "deep_mop_washing": {
-        "name": "Rentat profund de mopa"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Neteja personalitzada"
-      },
-      "carpet_preferences": {
-        "name": "Preferències personalitzades"
-      },
-      "wider_corner_coverage": {
-        "name": "Major cobertura de racons"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/ca.json
+++ b/custom_components/dreame_vacuum/translations/ca.json
@@ -1303,15 +1303,9 @@
         "name": "Neteja de rodes"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Neteja personalitzada"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Neteja profunda"
       },
       "auto_dust_collecting": {
         "name": "Buidat automàtic"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Autoneteja"
-      },
-      "deep_mop_washing": {
-        "name": "Rentat profund de mopa"
       },
       "hot_washing": {
         "name": "Rentat amb aigua calenta"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "Esterilització UV"
       },
-      "customized_carpet_cleaning": {
-        "name": "Neteja personalitzada"
-      },
       "carpet_avoidance": {
         "name": "Evitar catifes"
-      },
-      "carpet_preferences": {
-        "name": "Preferències personalitzades"
       },
       "auto_change_mop": {
         "name": "Canvi automàtic de mopa"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Rentat intel·ligent de mopa"
-      },
-      "wider_corner_coverage": {
-        "name": "Major cobertura de racons"
       },
       "pressurized_cleaning": {
         "name": "Neteja pressuritzada"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "DnD"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Neteja profunda"
+      },
+      "deep_mop_washing": {
+        "name": "Rentat profund de mopa"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Neteja personalitzada"
+      },
+      "carpet_preferences": {
+        "name": "Preferències personalitzades"
+      },
+      "wider_corner_coverage": {
+        "name": "Major cobertura de racons"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/cs.json
+++ b/custom_components/dreame_vacuum/translations/cs.json
@@ -1303,15 +1303,9 @@
         "name": "Čištění kol"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Upravené čištění"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Hloubkové čištění"
       },
       "auto_dust_collecting": {
         "name": "Auto-vyprazdňování"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Samočištění"
-      },
-      "deep_mop_washing": {
-        "name": "Hloubkové mytí mopu"
       },
       "hot_washing": {
         "name": "Mytí horkou vodou"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV sterilizace"
       },
-      "customized_carpet_cleaning": {
-        "name": "Upravené čištění"
-      },
       "carpet_avoidance": {
         "name": "Vyhýbání se kobercům"
-      },
-      "carpet_preferences": {
-        "name": "Upravené preference"
       },
       "auto_change_mop": {
         "name": "Automatická výměna mopu"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Chytré mytí mopu"
-      },
-      "wider_corner_coverage": {
-        "name": "Širší pokrytí rohů"
       },
       "pressurized_cleaning": {
         "name": "Tlakové čištění"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "DnD"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Hloubkové čištění"
+      },
+      "deep_mop_washing": {
+        "name": "Hloubkové mytí mopu"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Upravené čištění"
+      },
+      "carpet_preferences": {
+        "name": "Upravené preference"
+      },
+      "wider_corner_coverage": {
+        "name": "Širší pokrytí rohů"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/cs.json
+++ b/custom_components/dreame_vacuum/translations/cs.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Upravené čištění"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Hloubkové čištění"
+      },
       "auto_dust_collecting": {
         "name": "Auto-vyprazdňování"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Samočištění"
+      },
+      "deep_mop_washing": {
+        "name": "Hloubkové mytí mopu"
       },
       "hot_washing": {
         "name": "Mytí horkou vodou"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV sterilizace"
       },
+      "customized_carpet_cleaning": {
+        "name": "Upravené čištění"
+      },
       "carpet_avoidance": {
         "name": "Vyhýbání se kobercům"
+      },
+      "carpet_preferences": {
+        "name": "Upravené preference"
       },
       "auto_change_mop": {
         "name": "Automatická výměna mopu"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Chytré mytí mopu"
+      },
+      "wider_corner_coverage": {
+        "name": "Širší pokrytí rohů"
       },
       "pressurized_cleaning": {
         "name": "Tlakové čištění"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "DnD"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Hloubkové čištění"
-      },
-      "deep_mop_washing": {
-        "name": "Hloubkové mytí mopu"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Upravené čištění"
-      },
-      "carpet_preferences": {
-        "name": "Upravené preference"
-      },
-      "wider_corner_coverage": {
-        "name": "Širší pokrytí rohů"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/da.json
+++ b/custom_components/dreame_vacuum/translations/da.json
@@ -1303,15 +1303,9 @@
         "name": "Hjulrengøring"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Brugerdefineret rengøring"
-      },
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Dybdegående rengøring"
       },
       "auto_dust_collecting": {
         "name": "Auto-tømning"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Selvrensning"
-      },
-      "deep_mop_washing": {
-        "name": "Dyb moppevask"
       },
       "hot_washing": {
         "name": "Varmtvandsvask"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV-sterilisering"
       },
-      "customized_carpet_cleaning": {
-        "name": "Brugerdefineret rengøring"
-      },
       "carpet_avoidance": {
         "name": "Tæppeundgåelse"
-      },
-      "carpet_preferences": {
-        "name": "Brugerdefinerede præferencer"
       },
       "auto_change_mop": {
         "name": "Automatisk moppeskift"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Smart-moppevask"
-      },
-      "wider_corner_coverage": {
-        "name": "Bredere hjørnedækning"
       },
       "pressurized_cleaning": {
         "name": "Trykrengøring"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "Forstyr ikke"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Dybdegående rengøring"
+      },
+      "deep_mop_washing": {
+        "name": "Dyb moppevask"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Brugerdefineret rengøring"
+      },
+      "carpet_preferences": {
+        "name": "Brugerdefinerede præferencer"
+      },
+      "wider_corner_coverage": {
+        "name": "Bredere hjørnedækning"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/da.json
+++ b/custom_components/dreame_vacuum/translations/da.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Brugerdefineret rengøring"
       },
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Dybdegående rengøring"
+      },
       "auto_dust_collecting": {
         "name": "Auto-tømning"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Selvrensning"
+      },
+      "deep_mop_washing": {
+        "name": "Dyb moppevask"
       },
       "hot_washing": {
         "name": "Varmtvandsvask"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV-sterilisering"
       },
+      "customized_carpet_cleaning": {
+        "name": "Brugerdefineret rengøring"
+      },
       "carpet_avoidance": {
         "name": "Tæppeundgåelse"
+      },
+      "carpet_preferences": {
+        "name": "Brugerdefinerede præferencer"
       },
       "auto_change_mop": {
         "name": "Automatisk moppeskift"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Smart-moppevask"
+      },
+      "wider_corner_coverage": {
+        "name": "Bredere hjørnedækning"
       },
       "pressurized_cleaning": {
         "name": "Trykrengøring"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "Forstyr ikke"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Dybdegående rengøring"
-      },
-      "deep_mop_washing": {
-        "name": "Dyb moppevask"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Brugerdefineret rengøring"
-      },
-      "carpet_preferences": {
-        "name": "Brugerdefinerede præferencer"
-      },
-      "wider_corner_coverage": {
-        "name": "Bredere hjørnedækning"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/de.json
+++ b/custom_components/dreame_vacuum/translations/de.json
@@ -1406,6 +1406,12 @@
       "customized_cleaning": {
         "name": "Individuelle Reinigung"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Tiefenreinigung"
+      },
       "auto_dust_collecting": {
         "name": "Automatische Entleerung"
       },
@@ -1414,6 +1420,9 @@
       },
       "self_clean": {
         "name": "Selbstreinigung"
+      },
+      "deep_mop_washing": {
+        "name": "Tiefenreinigung des Mopps"
       },
       "hot_washing": {
         "name": "Heißwasserwäsche"
@@ -1427,8 +1436,14 @@
       "uv_sterilization": {
         "name": "UV-Sterilisation"
       },
+      "customized_carpet_cleaning": {
+        "name": "Individuelle Reinigung"
+      },
       "carpet_avoidance": {
         "name": "Teppichvermeidung"
+      },
+      "carpet_preferences": {
+        "name": "Individuelle Einstellungen"
       },
       "auto_change_mop": {
         "name": "Automatischer Moppwechsel"
@@ -1486,6 +1501,9 @@
       },
       "smart_mop_washing": {
         "name": "Intelligente Moppwäsche"
+      },
+      "wider_corner_coverage": {
+        "name": "Größere Eckenabdeckung"
       },
       "pressurized_cleaning": {
         "name": "Druckreinigung"
@@ -1727,26 +1745,6 @@
       },
       "roller_cover_status": {
         "name": "Rollenabdeckung"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Tiefenreinigung"
-      },
-      "deep_mop_washing": {
-        "name": "Tiefenreinigung des Mopps"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Individuelle Reinigung"
-      },
-      "carpet_preferences": {
-        "name": "Individuelle Einstellungen"
-      },
-      "wider_corner_coverage": {
-        "name": "Größere Eckenabdeckung"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/de.json
+++ b/custom_components/dreame_vacuum/translations/de.json
@@ -582,6 +582,12 @@
           "three_seat_sofa_narrow": "Schmales Dreisitzer-Sofa",
           "l_shaped_sofa_right": "L-förmiges Sofa rechts"
         }
+      },
+      "map_rotation": {
+        "name": "Kartendrehung"
+      },
+      "selected_map": {
+        "name": "Ausgewählte Karte"
       }
     },
     "sensor": {
@@ -1301,6 +1307,99 @@
       },
       "wheel_dirty_left": {
         "name": "Radreinigung"
+      },
+      "battery_level": {
+        "name": "Batteriestand"
+      },
+      "cleaned_area": {
+        "name": "Gereinigte Fläche"
+      },
+      "cleaning_count": {
+        "name": "Anzahl Reinigungen"
+      },
+      "cleaning_history": {
+        "name": "Reinigungsverlauf"
+      },
+      "cleaning_progress": {
+        "name": "Reinigungsfortschritt"
+      },
+      "cleaning_time": {
+        "name": "Reinigungszeit"
+      },
+      "cruising_history": {
+        "name": "Fahrtverlauf"
+      },
+      "current_room": {
+        "name": "Aktueller Raum"
+      },
+      "deodorizer_time_left": {
+        "name": "Deodorisierer (Restzeit)"
+      },
+      "detergent_time_left": {
+        "name": "Reinigungsmittel (Restzeit)"
+      },
+      "drying_left": {
+        "name": "Trocknung (Restzeit)"
+      },
+      "drying_progress": {
+        "name": "Trocknungsfortschritt"
+      },
+      "dust_bag_drying_left": {
+        "name": "Staubbeutel-Trocknung (Restzeit)"
+      },
+      "filter_time_left": {
+        "name": "Filter (Restzeit)"
+      },
+      "first_cleaning_date": {
+        "name": "Erste Reinigung"
+      },
+      "fluffing_roller_dirty_time_left": {
+        "name": "Flusenwalzenreinigung (Restzeit)"
+      },
+      "main_brush_time_left": {
+        "name": "Hauptbürste (Restzeit)"
+      },
+      "mapping_time": {
+        "name": "Kartierungszeit"
+      },
+      "mop_pad_time_left": {
+        "name": "Mopp-Pad (Restzeit)"
+      },
+      "onboard_dirty_water_tank_time_left": {
+        "name": "Interner Schmutzwassertank (Restzeit)"
+      },
+      "roller_mop_filter_dirty_time_left": {
+        "name": "Walzenmopp-Filterreinigung (Restzeit)"
+      },
+      "scale_inhibitor_time_left": {
+        "name": "Kalkschutzmittel (Restzeit)"
+      },
+      "sensor_dirty_time_left": {
+        "name": "Sensorreinigung (Restzeit)"
+      },
+      "side_brush_time_left": {
+        "name": "Seitenbürste (Restzeit)"
+      },
+      "silver_ion_time_left": {
+        "name": "Silberion (Restzeit)"
+      },
+      "squeegee_time_left": {
+        "name": "Abzieher (Restzeit)"
+      },
+      "tank_filter_time_left": {
+        "name": "Tankfilter (Restzeit)"
+      },
+      "total_cleaned_area": {
+        "name": "Gesamte gereinigte Fläche"
+      },
+      "total_cleaning_time": {
+        "name": "Gesamte Reinigungszeit"
+      },
+      "water_outlet_filter_dirty_time_left": {
+        "name": "Wasserauslass-Filterreinigung (Restzeit)"
+      },
+      "wheel_dirty_time_left": {
+        "name": "Radreinigung (Restzeit)"
       }
     },
     "switch": {
@@ -1456,6 +1555,178 @@
       },
       "dnd": {
         "name": "DnD"
+      },
+      "ai_fluid_detection": {
+        "name": "KI-Flüssigkeitserkennung"
+      },
+      "ai_furniture_detection": {
+        "name": "KI-Möbelerkennung"
+      },
+      "ai_human_detection": {
+        "name": "KI-Personenerkennung"
+      },
+      "ai_obstacle_image_upload": {
+        "name": "KI-Hindernisbild-Upload"
+      },
+      "ai_pet_avoidance": {
+        "name": "KI-Haustiervermeidung"
+      },
+      "auto_charging": {
+        "name": "Intelligentes Laden"
+      },
+      "auto_water_refilling": {
+        "name": "Automatische Wasserzufuhr"
+      },
+      "camera_light_brightness_auto": {
+        "name": "Kameralicht-Helligkeit automatisch"
+      },
+      "cleaning_sequence": {
+        "name": "Individuelle Reinigungsreihenfolge"
+      },
+      "dust_bag_drying": {
+        "name": "Staubbeutel-Trocknung"
+      },
+      "fuzzy_obstacle_detection": {
+        "name": "Unscharfe Hinderniserkennung"
+      },
+      "human_follow": {
+        "name": "Personenverfolgung"
+      },
+      "lds_state": {
+        "name": "LDS-Modul anheben"
+      },
+      "max_suction_power": {
+        "name": "Maximale Saugkraft"
+      },
+      "mop_extend": {
+        "name": "Mopp-Ausfahren"
+      },
+      "pet_picture": {
+        "name": "Haustierbilder"
+      },
+      "self_clean_by_zone": {
+        "name": "Selbstreinigung nach Zimmer"
+      },
+      "side_reach": {
+        "name": "Seitenbürsten-Ausfahren"
+      },
+      "smart_drying": {
+        "name": "Intelligente Trocknung"
+      },
+      "stain_avoidance": {
+        "name": "Fleckenvermeidung"
+      },
+      "tight_mopping": {
+        "name": "Enges Wischmuster"
+      },
+      "ultra_clean_mode": {
+        "name": "Ultra-Moppwäsche"
+      },
+      "water_electrolysis": {
+        "name": "Wasserelektrolyse"
+      }
+    },
+    "button": {
+      "backup_saved_map": {
+        "name": "Karte sichern"
+      },
+      "base_station_cleaning": {
+        "name": "Basisstation reinigen"
+      },
+      "base_station_self_repair": {
+        "name": "Selbstreparatur starten"
+      },
+      "clear_warning": {
+        "name": "Warnung löschen"
+      },
+      "empty_water_tank": {
+        "name": "Frischwassertank leeren"
+      },
+      "manual_drying": {
+        "name": "Trocknung starten/stoppen"
+      },
+      "manual_dust_bag_drying": {
+        "name": "Staubbeutel-Trocknung starten/stoppen"
+      },
+      "reload_shortcuts": {
+        "name": "Kurzbefehle neu laden"
+      },
+      "reset_deodorizer": {
+        "name": "Deodorisierer zurücksetzen"
+      },
+      "reset_detergent": {
+        "name": "Reinigungsmittel zurücksetzen"
+      },
+      "reset_dirty_water_channel": {
+        "name": "Schmutzwasserkanal zurücksetzen"
+      },
+      "reset_filter": {
+        "name": "Filter zurücksetzen"
+      },
+      "reset_fluffing_roller": {
+        "name": "Flusenwalze zurücksetzen"
+      },
+      "reset_main_brush": {
+        "name": "Hauptbürste zurücksetzen"
+      },
+      "reset_mop_pad": {
+        "name": "Mopp-Pad zurücksetzen"
+      },
+      "reset_onboard_dirty_water_tank": {
+        "name": "Internen Schmutzwassertank zurücksetzen"
+      },
+      "reset_roller_mop_filter": {
+        "name": "Walzenmopp-Filter zurücksetzen"
+      },
+      "reset_scale_inhibitor": {
+        "name": "Kalkschutzmittel zurücksetzen"
+      },
+      "reset_sensor": {
+        "name": "Sensorreinigung zurücksetzen"
+      },
+      "reset_side_brush": {
+        "name": "Seitenbürste zurücksetzen"
+      },
+      "reset_silver_ion": {
+        "name": "Silberion zurücksetzen"
+      },
+      "reset_squeegee": {
+        "name": "Abzieher zurücksetzen"
+      },
+      "reset_water_outlet_filter": {
+        "name": "Wasserauslass-Filter zurücksetzen"
+      },
+      "reset_wheel": {
+        "name": "Radreinigung zurücksetzen"
+      },
+      "self_clean": {
+        "name": "Moppwäsche starten/pausieren"
+      },
+      "start_auto_empty": {
+        "name": "Automatische Entleerung starten"
+      },
+      "start_fast_mapping": {
+        "name": "Schnellkartierung starten"
+      },
+      "start_mapping": {
+        "name": "Kartierung starten"
+      },
+      "start_recleaning": {
+        "name": "Nachreinigung starten"
+      },
+      "water_tank_draining": {
+        "name": "Entwässerung starten"
+      }
+    },
+    "binary_sensor": {
+      "charging_state": {
+        "name": "Ladevorgang"
+      },
+      "lds_status": {
+        "name": "LDS-Status"
+      },
+      "roller_cover_status": {
+        "name": "Rollenabdeckung"
       }
     },
     "toggle": {
@@ -1496,6 +1767,12 @@
       },
       "volume": {
         "name": "Lautstärke"
+      },
+      "camera_light_brightness": {
+        "name": "Kameralicht-Helligkeit"
+      },
+      "mop_cleaning_remainder": {
+        "name": "Mopp-Reinigungserinnerung"
       }
     },
     "time": {

--- a/custom_components/dreame_vacuum/translations/de.json
+++ b/custom_components/dreame_vacuum/translations/de.json
@@ -1303,15 +1303,9 @@
         "name": "Radreinigung"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Individuelle Reinigung"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Tiefenreinigung"
       },
       "auto_dust_collecting": {
         "name": "Automatische Entleerung"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Selbstreinigung"
-      },
-      "deep_mop_washing": {
-        "name": "Tiefenreinigung des Mopps"
       },
       "hot_washing": {
         "name": "Heißwasserwäsche"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV-Sterilisation"
       },
-      "customized_carpet_cleaning": {
-        "name": "Individuelle Reinigung"
-      },
       "carpet_avoidance": {
         "name": "Teppichvermeidung"
-      },
-      "carpet_preferences": {
-        "name": "Individuelle Einstellungen"
       },
       "auto_change_mop": {
         "name": "Automatischer Moppwechsel"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Intelligente Moppwäsche"
-      },
-      "wider_corner_coverage": {
-        "name": "Größere Eckenabdeckung"
       },
       "pressurized_cleaning": {
         "name": "Druckreinigung"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "DnD"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Tiefenreinigung"
+      },
+      "deep_mop_washing": {
+        "name": "Tiefenreinigung des Mopps"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Individuelle Reinigung"
+      },
+      "carpet_preferences": {
+        "name": "Individuelle Einstellungen"
+      },
+      "wider_corner_coverage": {
+        "name": "Größere Eckenabdeckung"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/el.json
+++ b/custom_components/dreame_vacuum/translations/el.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Προσαρμοσμένος καθαρισμός"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Βαθύς καθαρισμός"
+      },
       "auto_dust_collecting": {
         "name": "Αυτόματο άδειασμα"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Αυτοκαθαρισμός"
+      },
+      "deep_mop_washing": {
+        "name": "Βαθύ πλύσιμο πανιού"
       },
       "hot_washing": {
         "name": "Πλύσιμο με ζεστό νερό"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "Αποστείρωση UV"
       },
+      "customized_carpet_cleaning": {
+        "name": "Προσαρμοσμένος καθαρισμός"
+      },
       "carpet_avoidance": {
         "name": "Αποφυγή χαλιών"
+      },
+      "carpet_preferences": {
+        "name": "Προσαρμοσμένες προτιμήσεις"
       },
       "auto_change_mop": {
         "name": "Αυτόματη αλλαγή πανιού"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Έξυπνο πλύσιμο πανιού"
+      },
+      "wider_corner_coverage": {
+        "name": "Μεγαλύτερη κάλυψη γωνιών"
       },
       "pressurized_cleaning": {
         "name": "Καθαρισμός υπό πίεση"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "DnD"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Βαθύς καθαρισμός"
-      },
-      "deep_mop_washing": {
-        "name": "Βαθύ πλύσιμο πανιού"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Προσαρμοσμένος καθαρισμός"
-      },
-      "carpet_preferences": {
-        "name": "Προσαρμοσμένες προτιμήσεις"
-      },
-      "wider_corner_coverage": {
-        "name": "Μεγαλύτερη κάλυψη γωνιών"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/el.json
+++ b/custom_components/dreame_vacuum/translations/el.json
@@ -1303,15 +1303,9 @@
         "name": "Καθαρισμός τροχών"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Προσαρμοσμένος καθαρισμός"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Βαθύς καθαρισμός"
       },
       "auto_dust_collecting": {
         "name": "Αυτόματο άδειασμα"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Αυτοκαθαρισμός"
-      },
-      "deep_mop_washing": {
-        "name": "Βαθύ πλύσιμο πανιού"
       },
       "hot_washing": {
         "name": "Πλύσιμο με ζεστό νερό"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "Αποστείρωση UV"
       },
-      "customized_carpet_cleaning": {
-        "name": "Προσαρμοσμένος καθαρισμός"
-      },
       "carpet_avoidance": {
         "name": "Αποφυγή χαλιών"
-      },
-      "carpet_preferences": {
-        "name": "Προσαρμοσμένες προτιμήσεις"
       },
       "auto_change_mop": {
         "name": "Αυτόματη αλλαγή πανιού"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Έξυπνο πλύσιμο πανιού"
-      },
-      "wider_corner_coverage": {
-        "name": "Μεγαλύτερη κάλυψη γωνιών"
       },
       "pressurized_cleaning": {
         "name": "Καθαρισμός υπό πίεση"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "DnD"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Βαθύς καθαρισμός"
+      },
+      "deep_mop_washing": {
+        "name": "Βαθύ πλύσιμο πανιού"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Προσαρμοσμένος καθαρισμός"
+      },
+      "carpet_preferences": {
+        "name": "Προσαρμοσμένες προτιμήσεις"
+      },
+      "wider_corner_coverage": {
+        "name": "Μεγαλύτερη κάλυψη γωνιών"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/en.json
+++ b/custom_components/dreame_vacuum/translations/en.json
@@ -582,6 +582,12 @@
           "three_seat_sofa_narrow": "Three-Seat sofa narrow",
           "l_shaped_sofa_right": "L-Shaped sofa right"
         }
+      },
+      "map_rotation": {
+        "name": "Map Rotation"
+      },
+      "selected_map": {
+        "name": "Selected Map"
       }
     },
     "sensor": {
@@ -1301,6 +1307,99 @@
       },
       "wheel_dirty_left": {
         "name": "Wheel Cleaning"
+      },
+      "battery_level": {
+        "name": "Battery Level"
+      },
+      "cleaned_area": {
+        "name": "Cleaned Area"
+      },
+      "cleaning_count": {
+        "name": "Cleaning Count"
+      },
+      "cleaning_history": {
+        "name": "Cleaning History"
+      },
+      "cleaning_progress": {
+        "name": "Cleaning Progress"
+      },
+      "cleaning_time": {
+        "name": "Cleaning Time"
+      },
+      "cruising_history": {
+        "name": "Cruising History"
+      },
+      "current_room": {
+        "name": "Current Room"
+      },
+      "deodorizer_time_left": {
+        "name": "Deodorizer Time Left"
+      },
+      "detergent_time_left": {
+        "name": "Detergent Time Left"
+      },
+      "drying_left": {
+        "name": "Drying Left"
+      },
+      "drying_progress": {
+        "name": "Drying Progress"
+      },
+      "dust_bag_drying_left": {
+        "name": "Dust Bag Drying Left"
+      },
+      "filter_time_left": {
+        "name": "Filter Time Left"
+      },
+      "first_cleaning_date": {
+        "name": "First Cleaning Date"
+      },
+      "fluffing_roller_dirty_time_left": {
+        "name": "Fluffing Roller Dirty Time Left"
+      },
+      "main_brush_time_left": {
+        "name": "Main Brush Time Left"
+      },
+      "mapping_time": {
+        "name": "Mapping Time"
+      },
+      "mop_pad_time_left": {
+        "name": "Mop Pad Time Left"
+      },
+      "onboard_dirty_water_tank_time_left": {
+        "name": "Onboard Dirty Water Tank Time Left"
+      },
+      "roller_mop_filter_dirty_time_left": {
+        "name": "Roller Mop Filter Dirty Time Left"
+      },
+      "scale_inhibitor_time_left": {
+        "name": "Scale Inhibitor Time Left"
+      },
+      "sensor_dirty_time_left": {
+        "name": "Sensor Dirty Time Left"
+      },
+      "side_brush_time_left": {
+        "name": "Side Brush Time Left"
+      },
+      "silver_ion_time_left": {
+        "name": "Silver-ion Time Left"
+      },
+      "squeegee_time_left": {
+        "name": "Squeegee Time Left"
+      },
+      "tank_filter_time_left": {
+        "name": "Tank Filter Time Left"
+      },
+      "total_cleaned_area": {
+        "name": "Total Cleaned Area"
+      },
+      "total_cleaning_time": {
+        "name": "Total Cleaning Time"
+      },
+      "water_outlet_filter_dirty_time_left": {
+        "name": "Water Outlet Filter Dirty Time Left"
+      },
+      "wheel_dirty_time_left": {
+        "name": "Wheel Dirty Time Left"
       }
     },
     "switch": {
@@ -1456,6 +1555,178 @@
       },
       "dnd": {
         "name": "DnD"
+      },
+      "ai_fluid_detection": {
+        "name": "AI Fluid Detection"
+      },
+      "ai_furniture_detection": {
+        "name": "AI Furniture Detection"
+      },
+      "ai_human_detection": {
+        "name": "AI Human Detection"
+      },
+      "ai_obstacle_image_upload": {
+        "name": "AI Obstacle Image Upload"
+      },
+      "ai_pet_avoidance": {
+        "name": "AI Pet Avoidance"
+      },
+      "auto_charging": {
+        "name": "Auto Charging"
+      },
+      "auto_water_refilling": {
+        "name": "Auto Water Refilling"
+      },
+      "camera_light_brightness_auto": {
+        "name": "Camera Light Brightness Auto"
+      },
+      "cleaning_sequence": {
+        "name": "Cleaning Sequence"
+      },
+      "dust_bag_drying": {
+        "name": "Dust Bag Drying"
+      },
+      "fuzzy_obstacle_detection": {
+        "name": "Fuzzy Obstacle Detection"
+      },
+      "human_follow": {
+        "name": "Human Follow"
+      },
+      "lds_state": {
+        "name": "LDS State"
+      },
+      "max_suction_power": {
+        "name": "Max Suction Power"
+      },
+      "mop_extend": {
+        "name": "Mop Extend"
+      },
+      "pet_picture": {
+        "name": "Pet Picture"
+      },
+      "self_clean_by_zone": {
+        "name": "Self Clean By Zone"
+      },
+      "side_reach": {
+        "name": "Side Reach"
+      },
+      "smart_drying": {
+        "name": "Smart Drying"
+      },
+      "stain_avoidance": {
+        "name": "Stain Avoidance"
+      },
+      "tight_mopping": {
+        "name": "Tight Mopping"
+      },
+      "ultra_clean_mode": {
+        "name": "Ultra Clean Mode"
+      },
+      "water_electrolysis": {
+        "name": "Water Electrolysis"
+      }
+    },
+    "button": {
+      "backup_saved_map": {
+        "name": "Backup Saved Map"
+      },
+      "base_station_cleaning": {
+        "name": "Base Station Cleaning"
+      },
+      "base_station_self_repair": {
+        "name": "Base Station Self Repair"
+      },
+      "clear_warning": {
+        "name": "Clear Warning"
+      },
+      "empty_water_tank": {
+        "name": "Empty Water Tank"
+      },
+      "manual_drying": {
+        "name": "Manual Drying"
+      },
+      "manual_dust_bag_drying": {
+        "name": "Manual Dust Bag Drying"
+      },
+      "reload_shortcuts": {
+        "name": "Reload Shortcuts"
+      },
+      "reset_deodorizer": {
+        "name": "Reset Deodorizer"
+      },
+      "reset_detergent": {
+        "name": "Reset Detergent"
+      },
+      "reset_dirty_water_channel": {
+        "name": "Reset Dirty Water Channel"
+      },
+      "reset_filter": {
+        "name": "Reset Filter"
+      },
+      "reset_fluffing_roller": {
+        "name": "Reset Fluffing Roller"
+      },
+      "reset_main_brush": {
+        "name": "Reset Main Brush"
+      },
+      "reset_mop_pad": {
+        "name": "Reset Mop Pad"
+      },
+      "reset_onboard_dirty_water_tank": {
+        "name": "Reset Onboard Dirty Water Tank"
+      },
+      "reset_roller_mop_filter": {
+        "name": "Reset Roller Mop Filter"
+      },
+      "reset_scale_inhibitor": {
+        "name": "Reset Scale Inhibitor"
+      },
+      "reset_sensor": {
+        "name": "Reset Sensor"
+      },
+      "reset_side_brush": {
+        "name": "Reset Side Brush"
+      },
+      "reset_silver_ion": {
+        "name": "Reset Silver-ion"
+      },
+      "reset_squeegee": {
+        "name": "Reset Squeegee"
+      },
+      "reset_water_outlet_filter": {
+        "name": "Reset Water Outlet Filter"
+      },
+      "reset_wheel": {
+        "name": "Reset Wheel"
+      },
+      "self_clean": {
+        "name": "Self Clean"
+      },
+      "start_auto_empty": {
+        "name": "Start Auto Empty"
+      },
+      "start_fast_mapping": {
+        "name": "Start Fast Mapping"
+      },
+      "start_mapping": {
+        "name": "Start Mapping"
+      },
+      "start_recleaning": {
+        "name": "Start Re-Cleaning"
+      },
+      "water_tank_draining": {
+        "name": "Water Tank Draining"
+      }
+    },
+    "binary_sensor": {
+      "charging_state": {
+        "name": "Charging State"
+      },
+      "lds_status": {
+        "name": "LDS Status"
+      },
+      "roller_cover_status": {
+        "name": "Roller Cover Status"
       }
     },
     "toggle": {
@@ -1496,6 +1767,12 @@
       },
       "volume": {
         "name": "Volume"
+      },
+      "camera_light_brightness": {
+        "name": "Camera Light Brightness"
+      },
+      "mop_cleaning_remainder": {
+        "name": "Mop Cleaning Remainder"
       }
     },
     "time": {

--- a/custom_components/dreame_vacuum/translations/en.json
+++ b/custom_components/dreame_vacuum/translations/en.json
@@ -345,7 +345,7 @@
         }
       },
       "cleangenius": {
-        "name": "Cleangenius",
+        "name": "CleanGenius",
         "state": {
           "off": "Off",
           "routine_cleaning": "Routine cleaning",
@@ -353,7 +353,7 @@
         }
       },
       "cleangenius_mode": {
-        "name": "Cleangenius Mode",
+        "name": "CleanGenius Mode",
         "state": {
           "vacuum_and_mop": "Vacuum and Mop",
           "mop_after_vacuum": "Mop after Vacuum"
@@ -929,7 +929,7 @@
         }
       },
       "self_wash_base_status": {
-        "name": "Self Wash Base Status",
+        "name": "Self-Wash Base Status",
         "state": {
           "unknown": "Unknown",
           "idle": "Idle",
@@ -1303,15 +1303,9 @@
         "name": "Wheel Cleaning"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Customized Cleaning"
-      },
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Deep Cleaning"
       },
       "auto_dust_collecting": {
         "name": "Auto-Empty"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Self-Clean"
-      },
-      "deep_mop_washing": {
-        "name": "Deep Mop Washing"
       },
       "hot_washing": {
         "name": "Hot Washing"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV Sterilization"
       },
-      "customized_carpet_cleaning": {
-        "name": "Customized Cleaning"
-      },
       "carpet_avoidance": {
         "name": "Carpet Avoidance"
-      },
-      "carpet_preferences": {
-        "name": "Customized Preferences"
       },
       "auto_change_mop": {
         "name": "Auto Mop Changing"
@@ -1398,13 +1383,10 @@
         "name": "Mop-Washing With Detergent"
       },
       "auto_add_detergent": {
-        "name": "Auto Add Detergent"
+        "name": "Auto-Add Detergent"
       },
       "smart_mop_washing": {
         "name": "Smart Mop Washing"
-      },
-      "wider_corner_coverage": {
-        "name": "Wider Corner Coverage"
       },
       "pressurized_cleaning": {
         "name": "Pressurized Cleaning"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "DnD"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Deep Cleaning"
+      },
+      "deep_mop_washing": {
+        "name": "Deep Mop Washing"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Customized Cleaning"
+      },
+      "carpet_preferences": {
+        "name": "Customized Preferences"
+      },
+      "wider_corner_coverage": {
+        "name": "Wider Corner Coverage"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/en.json
+++ b/custom_components/dreame_vacuum/translations/en.json
@@ -1406,6 +1406,12 @@
       "customized_cleaning": {
         "name": "Customized Cleaning"
       },
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Deep Cleaning"
+      },
       "auto_dust_collecting": {
         "name": "Auto-Empty"
       },
@@ -1414,6 +1420,9 @@
       },
       "self_clean": {
         "name": "Self-Clean"
+      },
+      "deep_mop_washing": {
+        "name": "Deep Mop Washing"
       },
       "hot_washing": {
         "name": "Hot Washing"
@@ -1427,8 +1436,14 @@
       "uv_sterilization": {
         "name": "UV Sterilization"
       },
+      "customized_carpet_cleaning": {
+        "name": "Customized Cleaning"
+      },
       "carpet_avoidance": {
         "name": "Carpet Avoidance"
+      },
+      "carpet_preferences": {
+        "name": "Customized Preferences"
       },
       "auto_change_mop": {
         "name": "Auto Mop Changing"
@@ -1486,6 +1501,9 @@
       },
       "smart_mop_washing": {
         "name": "Smart Mop Washing"
+      },
+      "wider_corner_coverage": {
+        "name": "Wider Corner Coverage"
       },
       "pressurized_cleaning": {
         "name": "Pressurized Cleaning"
@@ -1727,26 +1745,6 @@
       },
       "roller_cover_status": {
         "name": "Roller Cover Status"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Deep Cleaning"
-      },
-      "deep_mop_washing": {
-        "name": "Deep Mop Washing"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Customized Cleaning"
-      },
-      "carpet_preferences": {
-        "name": "Customized Preferences"
-      },
-      "wider_corner_coverage": {
-        "name": "Wider Corner Coverage"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/es.json
+++ b/custom_components/dreame_vacuum/translations/es.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Limpieza personalizada"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Limpieza profunda"
+      },
       "auto_dust_collecting": {
         "name": "Vaciado automático"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Autolimpieza"
+      },
+      "deep_mop_washing": {
+        "name": "Lavado profundo de mopa"
       },
       "hot_washing": {
         "name": "Lavado con agua caliente"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "Esterilización UV"
       },
+      "customized_carpet_cleaning": {
+        "name": "Limpieza personalizada"
+      },
       "carpet_avoidance": {
         "name": "Evitar alfombras"
+      },
+      "carpet_preferences": {
+        "name": "Preferencias personalizadas"
       },
       "auto_change_mop": {
         "name": "Cambio automático de mopa"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Lavado inteligente de mopa"
+      },
+      "wider_corner_coverage": {
+        "name": "Mayor cobertura de esquinas"
       },
       "pressurized_cleaning": {
         "name": "Limpieza presurizada"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "DnD"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Limpieza profunda"
-      },
-      "deep_mop_washing": {
-        "name": "Lavado profundo de mopa"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Limpieza personalizada"
-      },
-      "carpet_preferences": {
-        "name": "Preferencias personalizadas"
-      },
-      "wider_corner_coverage": {
-        "name": "Mayor cobertura de esquinas"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/es.json
+++ b/custom_components/dreame_vacuum/translations/es.json
@@ -1303,15 +1303,9 @@
         "name": "Limpieza de ruedas"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Limpieza personalizada"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Limpieza profunda"
       },
       "auto_dust_collecting": {
         "name": "Vaciado automático"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Autolimpieza"
-      },
-      "deep_mop_washing": {
-        "name": "Lavado profundo de mopa"
       },
       "hot_washing": {
         "name": "Lavado con agua caliente"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "Esterilización UV"
       },
-      "customized_carpet_cleaning": {
-        "name": "Limpieza personalizada"
-      },
       "carpet_avoidance": {
         "name": "Evitar alfombras"
-      },
-      "carpet_preferences": {
-        "name": "Preferencias personalizadas"
       },
       "auto_change_mop": {
         "name": "Cambio automático de mopa"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Lavado inteligente de mopa"
-      },
-      "wider_corner_coverage": {
-        "name": "Mayor cobertura de esquinas"
       },
       "pressurized_cleaning": {
         "name": "Limpieza presurizada"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "DnD"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Limpieza profunda"
+      },
+      "deep_mop_washing": {
+        "name": "Lavado profundo de mopa"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Limpieza personalizada"
+      },
+      "carpet_preferences": {
+        "name": "Preferencias personalizadas"
+      },
+      "wider_corner_coverage": {
+        "name": "Mayor cobertura de esquinas"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/et.json
+++ b/custom_components/dreame_vacuum/translations/et.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Kohandatud puhastus"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Süvapuhastus"
+      },
       "auto_dust_collecting": {
         "name": "Automaatne tühjendus"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Isepuhastus"
+      },
+      "deep_mop_washing": {
+        "name": "Sügav mopi pesemine"
       },
       "hot_washing": {
         "name": "Kuum pesu"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV-idandite hävitamine"
       },
+      "customized_carpet_cleaning": {
+        "name": "Kohandatud puhastus"
+      },
       "carpet_avoidance": {
         "name": "Vaiba vältimine"
+      },
+      "carpet_preferences": {
+        "name": "Kohandatud eelistused"
       },
       "auto_change_mop": {
         "name": "Automaatne mopi vahetus"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Nutikas mopopesu"
+      },
+      "wider_corner_coverage": {
+        "name": "Laiem nurkade katvus"
       },
       "pressurized_cleaning": {
         "name": "Survepesu"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "Mitte segada"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Süvapuhastus"
-      },
-      "deep_mop_washing": {
-        "name": "Sügav mopi pesemine"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Kohandatud puhastus"
-      },
-      "carpet_preferences": {
-        "name": "Kohandatud eelistused"
-      },
-      "wider_corner_coverage": {
-        "name": "Laiem nurkade katvus"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/et.json
+++ b/custom_components/dreame_vacuum/translations/et.json
@@ -1303,15 +1303,9 @@
         "name": "Ratta puhastamine"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Kohandatud puhastus"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Süvapuhastus"
       },
       "auto_dust_collecting": {
         "name": "Automaatne tühjendus"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Isepuhastus"
-      },
-      "deep_mop_washing": {
-        "name": "Sügav mopi pesemine"
       },
       "hot_washing": {
         "name": "Kuum pesu"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV-idandite hävitamine"
       },
-      "customized_carpet_cleaning": {
-        "name": "Kohandatud puhastus"
-      },
       "carpet_avoidance": {
         "name": "Vaiba vältimine"
-      },
-      "carpet_preferences": {
-        "name": "Kohandatud eelistused"
       },
       "auto_change_mop": {
         "name": "Automaatne mopi vahetus"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Nutikas mopopesu"
-      },
-      "wider_corner_coverage": {
-        "name": "Laiem nurkade katvus"
       },
       "pressurized_cleaning": {
         "name": "Survepesu"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "Mitte segada"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Süvapuhastus"
+      },
+      "deep_mop_washing": {
+        "name": "Sügav mopi pesemine"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Kohandatud puhastus"
+      },
+      "carpet_preferences": {
+        "name": "Kohandatud eelistused"
+      },
+      "wider_corner_coverage": {
+        "name": "Laiem nurkade katvus"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/fa.json
+++ b/custom_components/dreame_vacuum/translations/fa.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "تمیزکاری سفارشی"
       },
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "تمیزکاری عمیق"
+      },
       "auto_dust_collecting": {
         "name": "تخلیه خودکار زباله"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "خودتمیزکاری"
+      },
+      "deep_mop_washing": {
+        "name": "شستشوی عمیق طی"
       },
       "hot_washing": {
         "name": "شستشو با آب داغ"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "استریلیزاسیون UV"
       },
+      "customized_carpet_cleaning": {
+        "name": "تمیزکاری سفارشی"
+      },
       "carpet_avoidance": {
         "name": "اجتناب از فرش"
+      },
+      "carpet_preferences": {
+        "name": "تنظیمات سفارشی"
       },
       "auto_change_mop": {
         "name": "تعویض خودکار طی"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "شستشوی هوشمند طی"
+      },
+      "wider_corner_coverage": {
+        "name": "پوشش گسترده‌تر گوشه‌ها"
       },
       "pressurized_cleaning": {
         "name": "تمیزکاری تحت فشار"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "عدم مزاحمت (DnD)"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "تمیزکاری عمیق"
-      },
-      "deep_mop_washing": {
-        "name": "شستشوی عمیق طی"
-      },
-      "customized_carpet_cleaning": {
-        "name": "تمیزکاری سفارشی"
-      },
-      "carpet_preferences": {
-        "name": "تنظیمات سفارشی"
-      },
-      "wider_corner_coverage": {
-        "name": "پوشش گسترده‌تر گوشه‌ها"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/fa.json
+++ b/custom_components/dreame_vacuum/translations/fa.json
@@ -1303,15 +1303,9 @@
         "name": "تمیزی چرخ‌ها"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "تمیزکاری سفارشی"
-      },
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "تمیزکاری عمیق"
       },
       "auto_dust_collecting": {
         "name": "تخلیه خودکار زباله"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "خودتمیزکاری"
-      },
-      "deep_mop_washing": {
-        "name": "شستشوی عمیق طی"
       },
       "hot_washing": {
         "name": "شستشو با آب داغ"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "استریلیزاسیون UV"
       },
-      "customized_carpet_cleaning": {
-        "name": "تمیزکاری سفارشی"
-      },
       "carpet_avoidance": {
         "name": "اجتناب از فرش"
-      },
-      "carpet_preferences": {
-        "name": "تنظیمات سفارشی"
       },
       "auto_change_mop": {
         "name": "تعویض خودکار طی"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "شستشوی هوشمند طی"
-      },
-      "wider_corner_coverage": {
-        "name": "پوشش گسترده‌تر گوشه‌ها"
       },
       "pressurized_cleaning": {
         "name": "تمیزکاری تحت فشار"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "عدم مزاحمت (DnD)"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "تمیزکاری عمیق"
+      },
+      "deep_mop_washing": {
+        "name": "شستشوی عمیق طی"
+      },
+      "customized_carpet_cleaning": {
+        "name": "تمیزکاری سفارشی"
+      },
+      "carpet_preferences": {
+        "name": "تنظیمات سفارشی"
+      },
+      "wider_corner_coverage": {
+        "name": "پوشش گسترده‌تر گوشه‌ها"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/fi.json
+++ b/custom_components/dreame_vacuum/translations/fi.json
@@ -1303,15 +1303,9 @@
         "name": "Pyörän puhdistus"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Mukautettu siivous"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Perusteellinen puhdistus"
       },
       "auto_dust_collecting": {
         "name": "Automaattityhjennys"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Itsepuhdistus"
-      },
-      "deep_mop_washing": {
-        "name": "Perusteellinen mopin pesu"
       },
       "hot_washing": {
         "name": "Kuuma pesu"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV-sterilointi"
       },
-      "customized_carpet_cleaning": {
-        "name": "Mukautettu siivous"
-      },
       "carpet_avoidance": {
         "name": "Maton välttäminen"
-      },
-      "carpet_preferences": {
-        "name": "Mukautetut mieltymykset"
       },
       "auto_change_mop": {
         "name": "Automaattinen mopin vaihto"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Älykäs mopipesu"
-      },
-      "wider_corner_coverage": {
-        "name": "Laajempi kulmien peitto"
       },
       "pressurized_cleaning": {
         "name": "Paineistettu siivous"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "Älä häiritse -tila (DnD)"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Perusteellinen puhdistus"
+      },
+      "deep_mop_washing": {
+        "name": "Perusteellinen mopin pesu"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Mukautettu siivous"
+      },
+      "carpet_preferences": {
+        "name": "Mukautetut mieltymykset"
+      },
+      "wider_corner_coverage": {
+        "name": "Laajempi kulmien peitto"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/fi.json
+++ b/custom_components/dreame_vacuum/translations/fi.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Mukautettu siivous"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Perusteellinen puhdistus"
+      },
       "auto_dust_collecting": {
         "name": "Automaattityhjennys"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Itsepuhdistus"
+      },
+      "deep_mop_washing": {
+        "name": "Perusteellinen mopin pesu"
       },
       "hot_washing": {
         "name": "Kuuma pesu"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV-sterilointi"
       },
+      "customized_carpet_cleaning": {
+        "name": "Mukautettu siivous"
+      },
       "carpet_avoidance": {
         "name": "Maton välttäminen"
+      },
+      "carpet_preferences": {
+        "name": "Mukautetut mieltymykset"
       },
       "auto_change_mop": {
         "name": "Automaattinen mopin vaihto"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Älykäs mopipesu"
+      },
+      "wider_corner_coverage": {
+        "name": "Laajempi kulmien peitto"
       },
       "pressurized_cleaning": {
         "name": "Paineistettu siivous"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "Älä häiritse -tila (DnD)"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Perusteellinen puhdistus"
-      },
-      "deep_mop_washing": {
-        "name": "Perusteellinen mopin pesu"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Mukautettu siivous"
-      },
-      "carpet_preferences": {
-        "name": "Mukautetut mieltymykset"
-      },
-      "wider_corner_coverage": {
-        "name": "Laajempi kulmien peitto"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/fr.json
+++ b/custom_components/dreame_vacuum/translations/fr.json
@@ -1303,15 +1303,9 @@
         "name": "Nettoyage roues"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Nettoyage personnalisé"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Nettoyage approfondi"
       },
       "auto_dust_collecting": {
         "name": "Vidage automatique"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Auto-nettoyage"
-      },
-      "deep_mop_washing": {
-        "name": "Lavage approfondi de la serpillière"
       },
       "hot_washing": {
         "name": "Lavage à l'eau chaude"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "Stérilisation UV"
       },
-      "customized_carpet_cleaning": {
-        "name": "Nettoyage personnalisé"
-      },
       "carpet_avoidance": {
         "name": "Évitement des tapis"
-      },
-      "carpet_preferences": {
-        "name": "Préférences personnalisées"
       },
       "auto_change_mop": {
         "name": "Changement automatique de serpillière"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Lavage intelligent de la serpillière"
-      },
-      "wider_corner_coverage": {
-        "name": "Couverture plus large des coins"
       },
       "pressurized_cleaning": {
         "name": "Nettoyage sous pression"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "DnD"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Nettoyage approfondi"
+      },
+      "deep_mop_washing": {
+        "name": "Lavage approfondi de la serpillière"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Nettoyage personnalisé"
+      },
+      "carpet_preferences": {
+        "name": "Préférences personnalisées"
+      },
+      "wider_corner_coverage": {
+        "name": "Couverture plus large des coins"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/fr.json
+++ b/custom_components/dreame_vacuum/translations/fr.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Nettoyage personnalisé"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Nettoyage approfondi"
+      },
       "auto_dust_collecting": {
         "name": "Vidage automatique"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Auto-nettoyage"
+      },
+      "deep_mop_washing": {
+        "name": "Lavage approfondi de la serpillière"
       },
       "hot_washing": {
         "name": "Lavage à l'eau chaude"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "Stérilisation UV"
       },
+      "customized_carpet_cleaning": {
+        "name": "Nettoyage personnalisé"
+      },
       "carpet_avoidance": {
         "name": "Évitement des tapis"
+      },
+      "carpet_preferences": {
+        "name": "Préférences personnalisées"
       },
       "auto_change_mop": {
         "name": "Changement automatique de serpillière"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Lavage intelligent de la serpillière"
+      },
+      "wider_corner_coverage": {
+        "name": "Couverture plus large des coins"
       },
       "pressurized_cleaning": {
         "name": "Nettoyage sous pression"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "DnD"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Nettoyage approfondi"
-      },
-      "deep_mop_washing": {
-        "name": "Lavage approfondi de la serpillière"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Nettoyage personnalisé"
-      },
-      "carpet_preferences": {
-        "name": "Préférences personnalisées"
-      },
-      "wider_corner_coverage": {
-        "name": "Couverture plus large des coins"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/he.json
+++ b/custom_components/dreame_vacuum/translations/he.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "ניקוי מותאם אישית"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "ניקוי עמוק"
+      },
       "auto_dust_collecting": {
         "name": "ריקון אוטומטי"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "ניקוי עצמי"
+      },
+      "deep_mop_washing": {
+        "name": "שטיפת מגב עמוקה"
       },
       "hot_washing": {
         "name": "שטיפה חמה"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "עיקור UV"
       },
+      "customized_carpet_cleaning": {
+        "name": "ניקוי מותאם אישית"
+      },
       "carpet_avoidance": {
         "name": "הימנעות משטיח"
+      },
+      "carpet_preferences": {
+        "name": "העדפות מותאמות אישית"
       },
       "auto_change_mop": {
         "name": "החלפת מגב אוטומטית"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "שטיפת מגב חכמה"
+      },
+      "wider_corner_coverage": {
+        "name": "כיסוי פינות רחב יותר"
       },
       "pressurized_cleaning": {
         "name": "ניקוי בלחץ"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "נא לא להפריע (DnD)"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "ניקוי עמוק"
-      },
-      "deep_mop_washing": {
-        "name": "שטיפת מגב עמוקה"
-      },
-      "customized_carpet_cleaning": {
-        "name": "ניקוי מותאם אישית"
-      },
-      "carpet_preferences": {
-        "name": "העדפות מותאמות אישית"
-      },
-      "wider_corner_coverage": {
-        "name": "כיסוי פינות רחב יותר"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/he.json
+++ b/custom_components/dreame_vacuum/translations/he.json
@@ -1303,15 +1303,9 @@
         "name": "ניקוי גלגלים"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "ניקוי מותאם אישית"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "ניקוי עמוק"
       },
       "auto_dust_collecting": {
         "name": "ריקון אוטומטי"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "ניקוי עצמי"
-      },
-      "deep_mop_washing": {
-        "name": "שטיפת מגב עמוקה"
       },
       "hot_washing": {
         "name": "שטיפה חמה"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "עיקור UV"
       },
-      "customized_carpet_cleaning": {
-        "name": "ניקוי מותאם אישית"
-      },
       "carpet_avoidance": {
         "name": "הימנעות משטיח"
-      },
-      "carpet_preferences": {
-        "name": "העדפות מותאמות אישית"
       },
       "auto_change_mop": {
         "name": "החלפת מגב אוטומטית"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "שטיפת מגב חכמה"
-      },
-      "wider_corner_coverage": {
-        "name": "כיסוי פינות רחב יותר"
       },
       "pressurized_cleaning": {
         "name": "ניקוי בלחץ"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "נא לא להפריע (DnD)"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "ניקוי עמוק"
+      },
+      "deep_mop_washing": {
+        "name": "שטיפת מגב עמוקה"
+      },
+      "customized_carpet_cleaning": {
+        "name": "ניקוי מותאם אישית"
+      },
+      "carpet_preferences": {
+        "name": "העדפות מותאמות אישית"
+      },
+      "wider_corner_coverage": {
+        "name": "כיסוי פינות רחב יותר"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/hi.json
+++ b/custom_components/dreame_vacuum/translations/hi.json
@@ -1303,15 +1303,9 @@
         "name": "पहिया सफाई"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "अनुकूलित सफाई"
-      },
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "गहरी सफाई"
       },
       "auto_dust_collecting": {
         "name": "ऑटो-एम्प्टी"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "स्वयं-सफाई"
-      },
-      "deep_mop_washing": {
-        "name": "गहरा मॉप धुलाई"
       },
       "hot_washing": {
         "name": "गर्म धुलाई"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "यूवी नसबंदी"
       },
-      "customized_carpet_cleaning": {
-        "name": "अनुकूलित सफाई"
-      },
       "carpet_avoidance": {
         "name": "कालीन बचाव"
-      },
-      "carpet_preferences": {
-        "name": "अनुकूलित प्राथमिकताएं"
       },
       "auto_change_mop": {
         "name": "ऑटो मॉप बदलना"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "स्मार्ट मॉप धुलाई"
-      },
-      "wider_corner_coverage": {
-        "name": "व्यापक कोना कवरेज"
       },
       "pressurized_cleaning": {
         "name": "दबावयुक्त सफाई"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "DnD"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "गहरी सफाई"
+      },
+      "deep_mop_washing": {
+        "name": "गहरा मॉप धुलाई"
+      },
+      "customized_carpet_cleaning": {
+        "name": "अनुकूलित सफाई"
+      },
+      "carpet_preferences": {
+        "name": "अनुकूलित प्राथमिकताएं"
+      },
+      "wider_corner_coverage": {
+        "name": "व्यापक कोना कवरेज"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/hi.json
+++ b/custom_components/dreame_vacuum/translations/hi.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "अनुकूलित सफाई"
       },
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "गहरी सफाई"
+      },
       "auto_dust_collecting": {
         "name": "ऑटो-एम्प्टी"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "स्वयं-सफाई"
+      },
+      "deep_mop_washing": {
+        "name": "गहरा मॉप धुलाई"
       },
       "hot_washing": {
         "name": "गर्म धुलाई"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "यूवी नसबंदी"
       },
+      "customized_carpet_cleaning": {
+        "name": "अनुकूलित सफाई"
+      },
       "carpet_avoidance": {
         "name": "कालीन बचाव"
+      },
+      "carpet_preferences": {
+        "name": "अनुकूलित प्राथमिकताएं"
       },
       "auto_change_mop": {
         "name": "ऑटो मॉप बदलना"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "स्मार्ट मॉप धुलाई"
+      },
+      "wider_corner_coverage": {
+        "name": "व्यापक कोना कवरेज"
       },
       "pressurized_cleaning": {
         "name": "दबावयुक्त सफाई"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "DnD"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "गहरी सफाई"
-      },
-      "deep_mop_washing": {
-        "name": "गहरा मॉप धुलाई"
-      },
-      "customized_carpet_cleaning": {
-        "name": "अनुकूलित सफाई"
-      },
-      "carpet_preferences": {
-        "name": "अनुकूलित प्राथमिकताएं"
-      },
-      "wider_corner_coverage": {
-        "name": "व्यापक कोना कवरेज"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/hr.json
+++ b/custom_components/dreame_vacuum/translations/hr.json
@@ -1303,15 +1303,9 @@
         "name": "Čišćenje kotača"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Prilagođeno čišćenje"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Dubinsko čišćenje"
       },
       "auto_dust_collecting": {
         "name": "Automatsko pražnjenje"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Samočišćenje"
-      },
-      "deep_mop_washing": {
-        "name": "Dubinsko pranje krpe"
       },
       "hot_washing": {
         "name": "Pranje toplom vodom"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV sterilizacija"
       },
-      "customized_carpet_cleaning": {
-        "name": "Prilagođeno čišćenje tepiha"
-      },
       "carpet_avoidance": {
         "name": "Izbjegavanje tepiha"
-      },
-      "carpet_preferences": {
-        "name": "Prilagođene postavke"
       },
       "auto_change_mop": {
         "name": "Automatska zamjena krpe"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Pametno pranje krpe"
-      },
-      "wider_corner_coverage": {
-        "name": "Šira pokrivenost kutova"
       },
       "pressurized_cleaning": {
         "name": "Čišćenje pod pritiskom"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "Ne ometaj (DnD)"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Dubinsko čišćenje"
+      },
+      "deep_mop_washing": {
+        "name": "Dubinsko pranje krpe"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Prilagođeno čišćenje tepiha"
+      },
+      "carpet_preferences": {
+        "name": "Prilagođene postavke"
+      },
+      "wider_corner_coverage": {
+        "name": "Šira pokrivenost kutova"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/hr.json
+++ b/custom_components/dreame_vacuum/translations/hr.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Prilagođeno čišćenje"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Dubinsko čišćenje"
+      },
       "auto_dust_collecting": {
         "name": "Automatsko pražnjenje"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Samočišćenje"
+      },
+      "deep_mop_washing": {
+        "name": "Dubinsko pranje krpe"
       },
       "hot_washing": {
         "name": "Pranje toplom vodom"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV sterilizacija"
       },
+      "customized_carpet_cleaning": {
+        "name": "Prilagođeno čišćenje tepiha"
+      },
       "carpet_avoidance": {
         "name": "Izbjegavanje tepiha"
+      },
+      "carpet_preferences": {
+        "name": "Prilagođene postavke"
       },
       "auto_change_mop": {
         "name": "Automatska zamjena krpe"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Pametno pranje krpe"
+      },
+      "wider_corner_coverage": {
+        "name": "Šira pokrivenost kutova"
       },
       "pressurized_cleaning": {
         "name": "Čišćenje pod pritiskom"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "Ne ometaj (DnD)"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Dubinsko čišćenje"
-      },
-      "deep_mop_washing": {
-        "name": "Dubinsko pranje krpe"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Prilagođeno čišćenje tepiha"
-      },
-      "carpet_preferences": {
-        "name": "Prilagođene postavke"
-      },
-      "wider_corner_coverage": {
-        "name": "Šira pokrivenost kutova"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/hu.json
+++ b/custom_components/dreame_vacuum/translations/hu.json
@@ -1303,15 +1303,9 @@
         "name": "Kerekek tisztítása"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Egyéni takarítás"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Mélytisztítás"
       },
       "auto_dust_collecting": {
         "name": "Automatikus ürítés"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Öntisztítás"
-      },
-      "deep_mop_washing": {
-        "name": "Felmosó alapos mosása"
       },
       "hot_washing": {
         "name": "Forró vizes mosás"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV sterilizálás"
       },
-      "customized_carpet_cleaning": {
-        "name": "Egyéni takarítás"
-      },
       "carpet_avoidance": {
         "name": "Szőnyeg elkerülése"
-      },
-      "carpet_preferences": {
-        "name": "Egyéni beállítások"
       },
       "auto_change_mop": {
         "name": "Felmosó automatikus cseréje"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Okos felmosómosás"
-      },
-      "wider_corner_coverage": {
-        "name": "Szélesebb saroklefedettség"
       },
       "pressurized_cleaning": {
         "name": "Nyomás alatti takarítás"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "Ne zavarjanak"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Mélytisztítás"
+      },
+      "deep_mop_washing": {
+        "name": "Felmosó alapos mosása"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Egyéni takarítás"
+      },
+      "carpet_preferences": {
+        "name": "Egyéni beállítások"
+      },
+      "wider_corner_coverage": {
+        "name": "Szélesebb saroklefedettség"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/hu.json
+++ b/custom_components/dreame_vacuum/translations/hu.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Egyéni takarítás"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Mélytisztítás"
+      },
       "auto_dust_collecting": {
         "name": "Automatikus ürítés"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Öntisztítás"
+      },
+      "deep_mop_washing": {
+        "name": "Felmosó alapos mosása"
       },
       "hot_washing": {
         "name": "Forró vizes mosás"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV sterilizálás"
       },
+      "customized_carpet_cleaning": {
+        "name": "Egyéni takarítás"
+      },
       "carpet_avoidance": {
         "name": "Szőnyeg elkerülése"
+      },
+      "carpet_preferences": {
+        "name": "Egyéni beállítások"
       },
       "auto_change_mop": {
         "name": "Felmosó automatikus cseréje"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Okos felmosómosás"
+      },
+      "wider_corner_coverage": {
+        "name": "Szélesebb saroklefedettség"
       },
       "pressurized_cleaning": {
         "name": "Nyomás alatti takarítás"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "Ne zavarjanak"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Mélytisztítás"
-      },
-      "deep_mop_washing": {
-        "name": "Felmosó alapos mosása"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Egyéni takarítás"
-      },
-      "carpet_preferences": {
-        "name": "Egyéni beállítások"
-      },
-      "wider_corner_coverage": {
-        "name": "Szélesebb saroklefedettség"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/id.json
+++ b/custom_components/dreame_vacuum/translations/id.json
@@ -1303,15 +1303,9 @@
         "name": "Pembersihan Roda"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Pembersihan Disesuaikan"
-      },
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Pembersihan Mendalam"
       },
       "auto_dust_collecting": {
         "name": "Kosong Otomatis"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Pembersihan Mandiri"
-      },
-      "deep_mop_washing": {
-        "name": "Pencucian Pel Mendalam"
       },
       "hot_washing": {
         "name": "Pencucian Panas"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "Sterilisasi UV"
       },
-      "customized_carpet_cleaning": {
-        "name": "Pembersihan Karpet Khusus"
-      },
       "carpet_avoidance": {
         "name": "Penghindaran Karpet"
-      },
-      "carpet_preferences": {
-        "name": "Preferensi yang Disesuaikan"
       },
       "auto_change_mop": {
         "name": "Pergantian Pel Otomatis"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Pencucian Pel Cerdas"
-      },
-      "wider_corner_coverage": {
-        "name": "Cakupan Sudut Lebih Lebar"
       },
       "pressurized_cleaning": {
         "name": "Pembersihan Bertekanan"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "DnD"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Pembersihan Mendalam"
+      },
+      "deep_mop_washing": {
+        "name": "Pencucian Pel Mendalam"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Pembersihan Karpet Khusus"
+      },
+      "carpet_preferences": {
+        "name": "Preferensi yang Disesuaikan"
+      },
+      "wider_corner_coverage": {
+        "name": "Cakupan Sudut Lebih Lebar"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/id.json
+++ b/custom_components/dreame_vacuum/translations/id.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Pembersihan Disesuaikan"
       },
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Pembersihan Mendalam"
+      },
       "auto_dust_collecting": {
         "name": "Kosong Otomatis"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Pembersihan Mandiri"
+      },
+      "deep_mop_washing": {
+        "name": "Pencucian Pel Mendalam"
       },
       "hot_washing": {
         "name": "Pencucian Panas"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "Sterilisasi UV"
       },
+      "customized_carpet_cleaning": {
+        "name": "Pembersihan Karpet Khusus"
+      },
       "carpet_avoidance": {
         "name": "Penghindaran Karpet"
+      },
+      "carpet_preferences": {
+        "name": "Preferensi yang Disesuaikan"
       },
       "auto_change_mop": {
         "name": "Pergantian Pel Otomatis"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Pencucian Pel Cerdas"
+      },
+      "wider_corner_coverage": {
+        "name": "Cakupan Sudut Lebih Lebar"
       },
       "pressurized_cleaning": {
         "name": "Pembersihan Bertekanan"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "DnD"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Pembersihan Mendalam"
-      },
-      "deep_mop_washing": {
-        "name": "Pencucian Pel Mendalam"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Pembersihan Karpet Khusus"
-      },
-      "carpet_preferences": {
-        "name": "Preferensi yang Disesuaikan"
-      },
-      "wider_corner_coverage": {
-        "name": "Cakupan Sudut Lebih Lebar"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/it.json
+++ b/custom_components/dreame_vacuum/translations/it.json
@@ -1304,15 +1304,9 @@
         "name": "Pulizia ruote"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Pulizia personalizzata"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Pulizia profonda"
       },
       "auto_dust_collecting": {
         "name": "Svuotamento automatico"
@@ -1322,9 +1316,6 @@
       },
       "self_clean": {
         "name": "Auto-pulizia"
-      },
-      "deep_mop_washing": {
-        "name": "Lavaggio profondo del panno"
       },
       "hot_washing": {
         "name": "Lavaggio con acqua calda"
@@ -1338,14 +1329,8 @@
       "uv_sterilization": {
         "name": "Sterilizzazione UV"
       },
-      "customized_carpet_cleaning": {
-        "name": "Pulizia personalizzata"
-      },
       "carpet_avoidance": {
         "name": "Evitamento tappeti"
-      },
-      "carpet_preferences": {
-        "name": "Preferenze personalizzate"
       },
       "auto_change_mop": {
         "name": "Cambio automatico del panno"
@@ -1403,9 +1388,6 @@
       },
       "smart_mop_washing": {
         "name": "Lavaggio intelligente del panno"
-      },
-      "wider_corner_coverage": {
-        "name": "Copertura angoli ampia"
       },
       "pressurized_cleaning": {
         "name": "Pulizia pressurizzata"
@@ -1475,6 +1457,26 @@
       },
       "dnd": {
         "name": "DnD"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Pulizia profonda"
+      },
+      "deep_mop_washing": {
+        "name": "Lavaggio profondo del panno"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Pulizia personalizzata"
+      },
+      "carpet_preferences": {
+        "name": "Preferenze personalizzate"
+      },
+      "wider_corner_coverage": {
+        "name": "Copertura angoli ampia"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/it.json
+++ b/custom_components/dreame_vacuum/translations/it.json
@@ -1308,6 +1308,12 @@
       "customized_cleaning": {
         "name": "Pulizia personalizzata"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Pulizia profonda"
+      },
       "auto_dust_collecting": {
         "name": "Svuotamento automatico"
       },
@@ -1316,6 +1322,9 @@
       },
       "self_clean": {
         "name": "Auto-pulizia"
+      },
+      "deep_mop_washing": {
+        "name": "Lavaggio profondo del panno"
       },
       "hot_washing": {
         "name": "Lavaggio con acqua calda"
@@ -1329,8 +1338,14 @@
       "uv_sterilization": {
         "name": "Sterilizzazione UV"
       },
+      "customized_carpet_cleaning": {
+        "name": "Pulizia personalizzata"
+      },
       "carpet_avoidance": {
         "name": "Evitamento tappeti"
+      },
+      "carpet_preferences": {
+        "name": "Preferenze personalizzate"
       },
       "auto_change_mop": {
         "name": "Cambio automatico del panno"
@@ -1388,6 +1403,9 @@
       },
       "smart_mop_washing": {
         "name": "Lavaggio intelligente del panno"
+      },
+      "wider_corner_coverage": {
+        "name": "Copertura angoli ampia"
       },
       "pressurized_cleaning": {
         "name": "Pulizia pressurizzata"
@@ -1457,26 +1475,6 @@
       },
       "dnd": {
         "name": "DnD"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Pulizia profonda"
-      },
-      "deep_mop_washing": {
-        "name": "Lavaggio profondo del panno"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Pulizia personalizzata"
-      },
-      "carpet_preferences": {
-        "name": "Preferenze personalizzate"
-      },
-      "wider_corner_coverage": {
-        "name": "Copertura angoli ampia"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/ja.json
+++ b/custom_components/dreame_vacuum/translations/ja.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "カスタマイズ清掃"
       },
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "徹底清掃"
+      },
       "auto_dust_collecting": {
         "name": "自動ゴミ収集"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "自動クリーニング"
+      },
+      "deep_mop_washing": {
+        "name": "しっかりモップ水洗い"
       },
       "hot_washing": {
         "name": "温水洗浄"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV除菌"
       },
+      "customized_carpet_cleaning": {
+        "name": "カスタマイズ清掃"
+      },
       "carpet_avoidance": {
         "name": "カーペット回避"
+      },
+      "carpet_preferences": {
+        "name": "カスタム設定"
       },
       "auto_change_mop": {
         "name": "自動モップ交換"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "スマートモップ洗浄"
+      },
+      "wider_corner_coverage": {
+        "name": "広範囲の隅の清掃"
       },
       "pressurized_cleaning": {
         "name": "加圧清掃"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "おやすみモード"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "徹底清掃"
-      },
-      "deep_mop_washing": {
-        "name": "しっかりモップ水洗い"
-      },
-      "customized_carpet_cleaning": {
-        "name": "カスタマイズ清掃"
-      },
-      "carpet_preferences": {
-        "name": "カスタム設定"
-      },
-      "wider_corner_coverage": {
-        "name": "広範囲の隅の清掃"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/ja.json
+++ b/custom_components/dreame_vacuum/translations/ja.json
@@ -1303,15 +1303,9 @@
         "name": "ホイールクリーニング"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "カスタマイズ清掃"
-      },
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "徹底清掃"
       },
       "auto_dust_collecting": {
         "name": "自動ゴミ収集"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "自動クリーニング"
-      },
-      "deep_mop_washing": {
-        "name": "しっかりモップ水洗い"
       },
       "hot_washing": {
         "name": "温水洗浄"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV除菌"
       },
-      "customized_carpet_cleaning": {
-        "name": "カスタマイズ清掃"
-      },
       "carpet_avoidance": {
         "name": "カーペット回避"
-      },
-      "carpet_preferences": {
-        "name": "カスタム設定"
       },
       "auto_change_mop": {
         "name": "自動モップ交換"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "スマートモップ洗浄"
-      },
-      "wider_corner_coverage": {
-        "name": "広範囲の隅の清掃"
       },
       "pressurized_cleaning": {
         "name": "加圧清掃"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "おやすみモード"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "徹底清掃"
+      },
+      "deep_mop_washing": {
+        "name": "しっかりモップ水洗い"
+      },
+      "customized_carpet_cleaning": {
+        "name": "カスタマイズ清掃"
+      },
+      "carpet_preferences": {
+        "name": "カスタム設定"
+      },
+      "wider_corner_coverage": {
+        "name": "広範囲の隅の清掃"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/ko.json
+++ b/custom_components/dreame_vacuum/translations/ko.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "맞춤 청소"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "정밀 청소"
+      },
       "auto_dust_collecting": {
         "name": "자동 먼지 비움"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "자가 청소"
+      },
+      "deep_mop_washing": {
+        "name": "정밀 걸레 세척"
       },
       "hot_washing": {
         "name": "온수 세척"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV 살균"
       },
+      "customized_carpet_cleaning": {
+        "name": "맞춤 청소"
+      },
       "carpet_avoidance": {
         "name": "카펫 회피"
+      },
+      "carpet_preferences": {
+        "name": "카펫 맞춤 설정"
       },
       "auto_change_mop": {
         "name": "자동 걸레 교체"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "스마트 걸레 세척"
+      },
+      "wider_corner_coverage": {
+        "name": "코너 청소 범위 확대"
       },
       "pressurized_cleaning": {
         "name": "가압 청소"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "방해 금지 모드"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "정밀 청소"
-      },
-      "deep_mop_washing": {
-        "name": "정밀 걸레 세척"
-      },
-      "customized_carpet_cleaning": {
-        "name": "맞춤 청소"
-      },
-      "carpet_preferences": {
-        "name": "카펫 맞춤 설정"
-      },
-      "wider_corner_coverage": {
-        "name": "코너 청소 범위 확대"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/ko.json
+++ b/custom_components/dreame_vacuum/translations/ko.json
@@ -1303,15 +1303,9 @@
         "name": "바퀴 청소"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "맞춤 청소"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "정밀 청소"
       },
       "auto_dust_collecting": {
         "name": "자동 먼지 비움"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "자가 청소"
-      },
-      "deep_mop_washing": {
-        "name": "정밀 걸레 세척"
       },
       "hot_washing": {
         "name": "온수 세척"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV 살균"
       },
-      "customized_carpet_cleaning": {
-        "name": "맞춤 청소"
-      },
       "carpet_avoidance": {
         "name": "카펫 회피"
-      },
-      "carpet_preferences": {
-        "name": "카펫 맞춤 설정"
       },
       "auto_change_mop": {
         "name": "자동 걸레 교체"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "스마트 걸레 세척"
-      },
-      "wider_corner_coverage": {
-        "name": "코너 청소 범위 확대"
       },
       "pressurized_cleaning": {
         "name": "가압 청소"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "방해 금지 모드"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "정밀 청소"
+      },
+      "deep_mop_washing": {
+        "name": "정밀 걸레 세척"
+      },
+      "customized_carpet_cleaning": {
+        "name": "맞춤 청소"
+      },
+      "carpet_preferences": {
+        "name": "카펫 맞춤 설정"
+      },
+      "wider_corner_coverage": {
+        "name": "코너 청소 범위 확대"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/lt.json
+++ b/custom_components/dreame_vacuum/translations/lt.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Pasirinktinis valymas"
       },
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Gilus valymas"
+      },
       "auto_dust_collecting": {
         "name": "Automatinis dulkių surinkimas"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Savaiminis išsivalymas"
+      },
+      "deep_mop_washing": {
+        "name": "Gilus šluostės plovimas"
       },
       "hot_washing": {
         "name": "Plovimas karštu vandeniu"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV sterilizacija"
       },
+      "customized_carpet_cleaning": {
+        "name": "Pasirinktinis kilimų valymas"
+      },
       "carpet_avoidance": {
         "name": "Kilimų vengimas"
+      },
+      "carpet_preferences": {
+        "name": "Pasirinktiniai nustatymai"
       },
       "auto_change_mop": {
         "name": "Automatinis šluostės keitimas"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Išmanusis šluostės plovimas"
+      },
+      "wider_corner_coverage": {
+        "name": "Platesnė kampų aprėptis"
       },
       "pressurized_cleaning": {
         "name": "Valymas su slėgiu"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "Netrukdymo režimas (DnD)"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Gilus valymas"
-      },
-      "deep_mop_washing": {
-        "name": "Gilus šluostės plovimas"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Pasirinktinis kilimų valymas"
-      },
-      "carpet_preferences": {
-        "name": "Pasirinktiniai nustatymai"
-      },
-      "wider_corner_coverage": {
-        "name": "Platesnė kampų aprėptis"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/lt.json
+++ b/custom_components/dreame_vacuum/translations/lt.json
@@ -1303,15 +1303,9 @@
         "name": "Ratų valymas"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Pasirinktinis valymas"
-      },
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Gilus valymas"
       },
       "auto_dust_collecting": {
         "name": "Automatinis dulkių surinkimas"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Savaiminis išsivalymas"
-      },
-      "deep_mop_washing": {
-        "name": "Gilus šluostės plovimas"
       },
       "hot_washing": {
         "name": "Plovimas karštu vandeniu"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV sterilizacija"
       },
-      "customized_carpet_cleaning": {
-        "name": "Pasirinktinis kilimų valymas"
-      },
       "carpet_avoidance": {
         "name": "Kilimų vengimas"
-      },
-      "carpet_preferences": {
-        "name": "Pasirinktiniai nustatymai"
       },
       "auto_change_mop": {
         "name": "Automatinis šluostės keitimas"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Išmanusis šluostės plovimas"
-      },
-      "wider_corner_coverage": {
-        "name": "Platesnė kampų aprėptis"
       },
       "pressurized_cleaning": {
         "name": "Valymas su slėgiu"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "Netrukdymo režimas (DnD)"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Gilus valymas"
+      },
+      "deep_mop_washing": {
+        "name": "Gilus šluostės plovimas"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Pasirinktinis kilimų valymas"
+      },
+      "carpet_preferences": {
+        "name": "Pasirinktiniai nustatymai"
+      },
+      "wider_corner_coverage": {
+        "name": "Platesnė kampų aprėptis"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/lv.json
+++ b/custom_components/dreame_vacuum/translations/lv.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Pielāgota tīrīšana"
       },
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Dziļā tīrīšana"
+      },
       "auto_dust_collecting": {
         "name": "Automātiska iztukšošana"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Pašattīrīšanās"
+      },
+      "deep_mop_washing": {
+        "name": "Dziļā mopa mazgāšana"
       },
       "hot_washing": {
         "name": "Mazgāšana ar karstu ūdeni"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV sterilizācija"
       },
+      "customized_carpet_cleaning": {
+        "name": "Pielāgota tīrīšana"
+      },
       "carpet_avoidance": {
         "name": "Izvairīšanās no paklājiem"
+      },
+      "carpet_preferences": {
+        "name": "Pielāgotas izvēles"
       },
       "auto_change_mop": {
         "name": "Automātiska mopa maiņa"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Viedā mopa mazgāšana"
+      },
+      "wider_corner_coverage": {
+        "name": "Plašāks stūru pārklājums"
       },
       "pressurized_cleaning": {
         "name": "Tīrīšana ar spiedienu"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "DnD"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Dziļā tīrīšana"
-      },
-      "deep_mop_washing": {
-        "name": "Dziļā mopa mazgāšana"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Pielāgota tīrīšana"
-      },
-      "carpet_preferences": {
-        "name": "Pielāgotas izvēles"
-      },
-      "wider_corner_coverage": {
-        "name": "Plašāks stūru pārklājums"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/lv.json
+++ b/custom_components/dreame_vacuum/translations/lv.json
@@ -1303,15 +1303,9 @@
         "name": "Riteņu tīrīšana"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Pielāgota tīrīšana"
-      },
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Dziļā tīrīšana"
       },
       "auto_dust_collecting": {
         "name": "Automātiska iztukšošana"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Pašattīrīšanās"
-      },
-      "deep_mop_washing": {
-        "name": "Dziļā mopa mazgāšana"
       },
       "hot_washing": {
         "name": "Mazgāšana ar karstu ūdeni"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV sterilizācija"
       },
-      "customized_carpet_cleaning": {
-        "name": "Pielāgota tīrīšana"
-      },
       "carpet_avoidance": {
         "name": "Izvairīšanās no paklājiem"
-      },
-      "carpet_preferences": {
-        "name": "Pielāgotas izvēles"
       },
       "auto_change_mop": {
         "name": "Automātiska mopa maiņa"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Viedā mopa mazgāšana"
-      },
-      "wider_corner_coverage": {
-        "name": "Plašāks stūru pārklājums"
       },
       "pressurized_cleaning": {
         "name": "Tīrīšana ar spiedienu"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "DnD"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Dziļā tīrīšana"
+      },
+      "deep_mop_washing": {
+        "name": "Dziļā mopa mazgāšana"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Pielāgota tīrīšana"
+      },
+      "carpet_preferences": {
+        "name": "Pielāgotas izvēles"
+      },
+      "wider_corner_coverage": {
+        "name": "Plašāks stūru pārklājums"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/ms.json
+++ b/custom_components/dreame_vacuum/translations/ms.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Pembersihan Tersuai"
       },
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Pembersihan Mendalam"
+      },
       "auto_dust_collecting": {
         "name": "Auto-Kosong"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Cuci Kendiri"
+      },
+      "deep_mop_washing": {
+        "name": "Basuhan Mop Mendalam"
       },
       "hot_washing": {
         "name": "Basuhan Panas"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "Pensterilan UV"
       },
+      "customized_carpet_cleaning": {
+        "name": "Pembersihan Tersuai"
+      },
       "carpet_avoidance": {
         "name": "Pengelakan Karpet"
+      },
+      "carpet_preferences": {
+        "name": "Keutamaan Tersuai"
       },
       "auto_change_mop": {
         "name": "Penukaran Mop Auto"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Basuhan Mop Pintar"
+      },
+      "wider_corner_coverage": {
+        "name": "Liputan Sudut Lebih Luas"
       },
       "pressurized_cleaning": {
         "name": "Pembersihan Bertekanan"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "DnD"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Pembersihan Mendalam"
-      },
-      "deep_mop_washing": {
-        "name": "Basuhan Mop Mendalam"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Pembersihan Tersuai"
-      },
-      "carpet_preferences": {
-        "name": "Keutamaan Tersuai"
-      },
-      "wider_corner_coverage": {
-        "name": "Liputan Sudut Lebih Luas"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/ms.json
+++ b/custom_components/dreame_vacuum/translations/ms.json
@@ -1303,15 +1303,9 @@
         "name": "Pembersihan Roda"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Pembersihan Tersuai"
-      },
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Pembersihan Mendalam"
       },
       "auto_dust_collecting": {
         "name": "Auto-Kosong"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Cuci Kendiri"
-      },
-      "deep_mop_washing": {
-        "name": "Basuhan Mop Mendalam"
       },
       "hot_washing": {
         "name": "Basuhan Panas"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "Pensterilan UV"
       },
-      "customized_carpet_cleaning": {
-        "name": "Pembersihan Tersuai"
-      },
       "carpet_avoidance": {
         "name": "Pengelakan Karpet"
-      },
-      "carpet_preferences": {
-        "name": "Keutamaan Tersuai"
       },
       "auto_change_mop": {
         "name": "Penukaran Mop Auto"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Basuhan Mop Pintar"
-      },
-      "wider_corner_coverage": {
-        "name": "Liputan Sudut Lebih Luas"
       },
       "pressurized_cleaning": {
         "name": "Pembersihan Bertekanan"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "DnD"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Pembersihan Mendalam"
+      },
+      "deep_mop_washing": {
+        "name": "Basuhan Mop Mendalam"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Pembersihan Tersuai"
+      },
+      "carpet_preferences": {
+        "name": "Keutamaan Tersuai"
+      },
+      "wider_corner_coverage": {
+        "name": "Liputan Sudut Lebih Luas"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/nl.json
+++ b/custom_components/dreame_vacuum/translations/nl.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Gepersonaliseerde reiniging"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Grondige reiniging"
+      },
       "auto_dust_collecting": {
         "name": "Automatisch legen"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Zelfreiniging"
+      },
+      "deep_mop_washing": {
+        "name": "Grondige dweilwas"
       },
       "hot_washing": {
         "name": "Wassen met heet water"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV-sterilisatie"
       },
+      "customized_carpet_cleaning": {
+        "name": "Gepersonaliseerde reiniging"
+      },
       "carpet_avoidance": {
         "name": "Tapijt vermijden"
+      },
+      "carpet_preferences": {
+        "name": "Gepersonaliseerde voorkeuren"
       },
       "auto_change_mop": {
         "name": "Automatische dweilwissel"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Slimme dweilwas"
+      },
+      "wider_corner_coverage": {
+        "name": "Bredere hoekdekking"
       },
       "pressurized_cleaning": {
         "name": "Onder druk reinigen"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "DnD"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Grondige reiniging"
-      },
-      "deep_mop_washing": {
-        "name": "Grondige dweilwas"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Gepersonaliseerde reiniging"
-      },
-      "carpet_preferences": {
-        "name": "Gepersonaliseerde voorkeuren"
-      },
-      "wider_corner_coverage": {
-        "name": "Bredere hoekdekking"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/nl.json
+++ b/custom_components/dreame_vacuum/translations/nl.json
@@ -1303,15 +1303,9 @@
         "name": "Wielen reinigen"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Gepersonaliseerde reiniging"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Grondige reiniging"
       },
       "auto_dust_collecting": {
         "name": "Automatisch legen"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Zelfreiniging"
-      },
-      "deep_mop_washing": {
-        "name": "Grondige dweilwas"
       },
       "hot_washing": {
         "name": "Wassen met heet water"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV-sterilisatie"
       },
-      "customized_carpet_cleaning": {
-        "name": "Gepersonaliseerde reiniging"
-      },
       "carpet_avoidance": {
         "name": "Tapijt vermijden"
-      },
-      "carpet_preferences": {
-        "name": "Gepersonaliseerde voorkeuren"
       },
       "auto_change_mop": {
         "name": "Automatische dweilwissel"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Slimme dweilwas"
-      },
-      "wider_corner_coverage": {
-        "name": "Bredere hoekdekking"
       },
       "pressurized_cleaning": {
         "name": "Onder druk reinigen"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "DnD"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Grondige reiniging"
+      },
+      "deep_mop_washing": {
+        "name": "Grondige dweilwas"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Gepersonaliseerde reiniging"
+      },
+      "carpet_preferences": {
+        "name": "Gepersonaliseerde voorkeuren"
+      },
+      "wider_corner_coverage": {
+        "name": "Bredere hoekdekking"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/no.json
+++ b/custom_components/dreame_vacuum/translations/no.json
@@ -1303,15 +1303,9 @@
         "name": "Hjulrengjøring"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Tilpasset rengjøring"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Dyprengjøring"
       },
       "auto_dust_collecting": {
         "name": "Auto-tømming"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Selvrens"
-      },
-      "deep_mop_washing": {
-        "name": "Dypmoppvask"
       },
       "hot_washing": {
         "name": "Varmvask"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV-sterilisering"
       },
-      "customized_carpet_cleaning": {
-        "name": "Tilpasset tepperengjøring"
-      },
       "carpet_avoidance": {
         "name": "Teppeunngåelse"
-      },
-      "carpet_preferences": {
-        "name": "Tilpassede preferanser"
       },
       "auto_change_mop": {
         "name": "Auto-moppeskift"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Smart moppevask"
-      },
-      "wider_corner_coverage": {
-        "name": "Bredere hjørnedekning"
       },
       "pressurized_cleaning": {
         "name": "Trykkrengjøring"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "DnD"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Dyprengjøring"
+      },
+      "deep_mop_washing": {
+        "name": "Dypmoppvask"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Tilpasset tepperengjøring"
+      },
+      "carpet_preferences": {
+        "name": "Tilpassede preferanser"
+      },
+      "wider_corner_coverage": {
+        "name": "Bredere hjørnedekning"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/no.json
+++ b/custom_components/dreame_vacuum/translations/no.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Tilpasset rengjøring"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Dyprengjøring"
+      },
       "auto_dust_collecting": {
         "name": "Auto-tømming"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Selvrens"
+      },
+      "deep_mop_washing": {
+        "name": "Dypmoppvask"
       },
       "hot_washing": {
         "name": "Varmvask"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV-sterilisering"
       },
+      "customized_carpet_cleaning": {
+        "name": "Tilpasset tepperengjøring"
+      },
       "carpet_avoidance": {
         "name": "Teppeunngåelse"
+      },
+      "carpet_preferences": {
+        "name": "Tilpassede preferanser"
       },
       "auto_change_mop": {
         "name": "Auto-moppeskift"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Smart moppevask"
+      },
+      "wider_corner_coverage": {
+        "name": "Bredere hjørnedekning"
       },
       "pressurized_cleaning": {
         "name": "Trykkrengjøring"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "DnD"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Dyprengjøring"
-      },
-      "deep_mop_washing": {
-        "name": "Dypmoppvask"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Tilpasset tepperengjøring"
-      },
-      "carpet_preferences": {
-        "name": "Tilpassede preferanser"
-      },
-      "wider_corner_coverage": {
-        "name": "Bredere hjørnedekning"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/pl.json
+++ b/custom_components/dreame_vacuum/translations/pl.json
@@ -1303,15 +1303,9 @@
         "name": "Czyszczenie kół"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Sprzątanie niestandardowe"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Głębokie czyszczenie"
       },
       "auto_dust_collecting": {
         "name": "Automatyczne opróżnianie"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Autoczyszczenie"
-      },
-      "deep_mop_washing": {
-        "name": "Głębokie mycie mopa"
       },
       "hot_washing": {
         "name": "Mycie gorącą wodą"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "Sterylizacja UV"
       },
-      "customized_carpet_cleaning": {
-        "name": "Sprzątanie niestandardowe"
-      },
       "carpet_avoidance": {
         "name": "Omijanie dywanów"
-      },
-      "carpet_preferences": {
-        "name": "Niestandardowe preferencje"
       },
       "auto_change_mop": {
         "name": "Automatyczna zmiana mopa"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Inteligentne mycie mopa"
-      },
-      "wider_corner_coverage": {
-        "name": "Szybsze pokrycie narożników"
       },
       "pressurized_cleaning": {
         "name": "Czyszczenie pod ciśnieniem"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "Tryb Nie przeszkadzać"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Głębokie czyszczenie"
+      },
+      "deep_mop_washing": {
+        "name": "Głębokie mycie mopa"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Sprzątanie niestandardowe"
+      },
+      "carpet_preferences": {
+        "name": "Niestandardowe preferencje"
+      },
+      "wider_corner_coverage": {
+        "name": "Szybsze pokrycie narożników"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/pl.json
+++ b/custom_components/dreame_vacuum/translations/pl.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Sprzątanie niestandardowe"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Głębokie czyszczenie"
+      },
       "auto_dust_collecting": {
         "name": "Automatyczne opróżnianie"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Autoczyszczenie"
+      },
+      "deep_mop_washing": {
+        "name": "Głębokie mycie mopa"
       },
       "hot_washing": {
         "name": "Mycie gorącą wodą"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "Sterylizacja UV"
       },
+      "customized_carpet_cleaning": {
+        "name": "Sprzątanie niestandardowe"
+      },
       "carpet_avoidance": {
         "name": "Omijanie dywanów"
+      },
+      "carpet_preferences": {
+        "name": "Niestandardowe preferencje"
       },
       "auto_change_mop": {
         "name": "Automatyczna zmiana mopa"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Inteligentne mycie mopa"
+      },
+      "wider_corner_coverage": {
+        "name": "Szybsze pokrycie narożników"
       },
       "pressurized_cleaning": {
         "name": "Czyszczenie pod ciśnieniem"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "Tryb Nie przeszkadzać"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Głębokie czyszczenie"
-      },
-      "deep_mop_washing": {
-        "name": "Głębokie mycie mopa"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Sprzątanie niestandardowe"
-      },
-      "carpet_preferences": {
-        "name": "Niestandardowe preferencje"
-      },
-      "wider_corner_coverage": {
-        "name": "Szybsze pokrycie narożników"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/pt-BR.json
+++ b/custom_components/dreame_vacuum/translations/pt-BR.json
@@ -1303,15 +1303,9 @@
         "name": "Limpeza das rodas"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Limpeza personalizada"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Limpeza profunda"
       },
       "auto_dust_collecting": {
         "name": "Esvaziamento automático"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Autolimpeza"
-      },
-      "deep_mop_washing": {
-        "name": "Lavagem profunda do mop"
       },
       "hot_washing": {
         "name": "Lavagem com água quente"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "Esterilização UV"
       },
-      "customized_carpet_cleaning": {
-        "name": "Limpeza personalizada"
-      },
       "carpet_avoidance": {
         "name": "Evitar tapetes"
-      },
-      "carpet_preferences": {
-        "name": "Preferências personalizadas"
       },
       "auto_change_mop": {
         "name": "Troca automática de mop"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Lavagem inteligente do mop"
-      },
-      "wider_corner_coverage": {
-        "name": "Cobertura de cantos ampliada"
       },
       "pressurized_cleaning": {
         "name": "Limpeza pressurizada"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "Não perturbe"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Limpeza profunda"
+      },
+      "deep_mop_washing": {
+        "name": "Lavagem profunda do mop"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Limpeza personalizada"
+      },
+      "carpet_preferences": {
+        "name": "Preferências personalizadas"
+      },
+      "wider_corner_coverage": {
+        "name": "Cobertura de cantos ampliada"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/pt-BR.json
+++ b/custom_components/dreame_vacuum/translations/pt-BR.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Limpeza personalizada"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Limpeza profunda"
+      },
       "auto_dust_collecting": {
         "name": "Esvaziamento automático"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Autolimpeza"
+      },
+      "deep_mop_washing": {
+        "name": "Lavagem profunda do mop"
       },
       "hot_washing": {
         "name": "Lavagem com água quente"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "Esterilização UV"
       },
+      "customized_carpet_cleaning": {
+        "name": "Limpeza personalizada"
+      },
       "carpet_avoidance": {
         "name": "Evitar tapetes"
+      },
+      "carpet_preferences": {
+        "name": "Preferências personalizadas"
       },
       "auto_change_mop": {
         "name": "Troca automática de mop"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Lavagem inteligente do mop"
+      },
+      "wider_corner_coverage": {
+        "name": "Cobertura de cantos ampliada"
       },
       "pressurized_cleaning": {
         "name": "Limpeza pressurizada"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "Não perturbe"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Limpeza profunda"
-      },
-      "deep_mop_washing": {
-        "name": "Lavagem profunda do mop"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Limpeza personalizada"
-      },
-      "carpet_preferences": {
-        "name": "Preferências personalizadas"
-      },
-      "wider_corner_coverage": {
-        "name": "Cobertura de cantos ampliada"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/pt.json
+++ b/custom_components/dreame_vacuum/translations/pt.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Limpeza personalizada"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Limpeza profunda"
+      },
       "auto_dust_collecting": {
         "name": "Esvaziamento automático"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Autolimpeza"
+      },
+      "deep_mop_washing": {
+        "name": "Lavagem profunda da mopa"
       },
       "hot_washing": {
         "name": "Lavagem com água quente"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "Esterilização UV"
       },
+      "customized_carpet_cleaning": {
+        "name": "Limpeza personalizada"
+      },
       "carpet_avoidance": {
         "name": "Evitar tapetes"
+      },
+      "carpet_preferences": {
+        "name": "Preferências personalizadas"
       },
       "auto_change_mop": {
         "name": "Troca automática de mopa"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Lavagem inteligente da mopa"
+      },
+      "wider_corner_coverage": {
+        "name": "Cobertura de cantos alargada"
       },
       "pressurized_cleaning": {
         "name": "Limpeza pressurizada"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "Não incomodar"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Limpeza profunda"
-      },
-      "deep_mop_washing": {
-        "name": "Lavagem profunda da mopa"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Limpeza personalizada"
-      },
-      "carpet_preferences": {
-        "name": "Preferências personalizadas"
-      },
-      "wider_corner_coverage": {
-        "name": "Cobertura de cantos alargada"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/pt.json
+++ b/custom_components/dreame_vacuum/translations/pt.json
@@ -1303,15 +1303,9 @@
         "name": "Limpeza das rodas"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Limpeza personalizada"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Limpeza profunda"
       },
       "auto_dust_collecting": {
         "name": "Esvaziamento automático"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Autolimpeza"
-      },
-      "deep_mop_washing": {
-        "name": "Lavagem profunda da mopa"
       },
       "hot_washing": {
         "name": "Lavagem com água quente"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "Esterilização UV"
       },
-      "customized_carpet_cleaning": {
-        "name": "Limpeza personalizada"
-      },
       "carpet_avoidance": {
         "name": "Evitar tapetes"
-      },
-      "carpet_preferences": {
-        "name": "Preferências personalizadas"
       },
       "auto_change_mop": {
         "name": "Troca automática de mopa"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Lavagem inteligente da mopa"
-      },
-      "wider_corner_coverage": {
-        "name": "Cobertura de cantos alargada"
       },
       "pressurized_cleaning": {
         "name": "Limpeza pressurizada"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "Não incomodar"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Limpeza profunda"
+      },
+      "deep_mop_washing": {
+        "name": "Lavagem profunda da mopa"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Limpeza personalizada"
+      },
+      "carpet_preferences": {
+        "name": "Preferências personalizadas"
+      },
+      "wider_corner_coverage": {
+        "name": "Cobertura de cantos alargada"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/ro.json
+++ b/custom_components/dreame_vacuum/translations/ro.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Curățare personalizată"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Curățare profundă"
+      },
       "auto_dust_collecting": {
         "name": "Golire automată"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Autocurățare"
+      },
+      "deep_mop_washing": {
+        "name": "Spălare profundă mop"
       },
       "hot_washing": {
         "name": "Spălare cu apă fierbinte"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "Sterilizare UV"
       },
+      "customized_carpet_cleaning": {
+        "name": "Curățare personalizată"
+      },
       "carpet_avoidance": {
         "name": "Evitare covoare"
+      },
+      "carpet_preferences": {
+        "name": "Preferințe personalizate"
       },
       "auto_change_mop": {
         "name": "Schimbare automată mop"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Spălare inteligentă mop"
+      },
+      "wider_corner_coverage": {
+        "name": "Acoperire mai mare a colțurilor"
       },
       "pressurized_cleaning": {
         "name": "Curățare presurizată"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "DnD"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Curățare profundă"
-      },
-      "deep_mop_washing": {
-        "name": "Spălare profundă mop"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Curățare personalizată"
-      },
-      "carpet_preferences": {
-        "name": "Preferințe personalizate"
-      },
-      "wider_corner_coverage": {
-        "name": "Acoperire mai mare a colțurilor"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/ro.json
+++ b/custom_components/dreame_vacuum/translations/ro.json
@@ -1303,15 +1303,9 @@
         "name": "Curățare roți"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Curățare personalizată"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Curățare profundă"
       },
       "auto_dust_collecting": {
         "name": "Golire automată"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Autocurățare"
-      },
-      "deep_mop_washing": {
-        "name": "Spălare profundă mop"
       },
       "hot_washing": {
         "name": "Spălare cu apă fierbinte"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "Sterilizare UV"
       },
-      "customized_carpet_cleaning": {
-        "name": "Curățare personalizată"
-      },
       "carpet_avoidance": {
         "name": "Evitare covoare"
-      },
-      "carpet_preferences": {
-        "name": "Preferințe personalizate"
       },
       "auto_change_mop": {
         "name": "Schimbare automată mop"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Spălare inteligentă mop"
-      },
-      "wider_corner_coverage": {
-        "name": "Acoperire mai mare a colțurilor"
       },
       "pressurized_cleaning": {
         "name": "Curățare presurizată"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "DnD"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Curățare profundă"
+      },
+      "deep_mop_washing": {
+        "name": "Spălare profundă mop"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Curățare personalizată"
+      },
+      "carpet_preferences": {
+        "name": "Preferințe personalizate"
+      },
+      "wider_corner_coverage": {
+        "name": "Acoperire mai mare a colțurilor"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/ru.json
+++ b/custom_components/dreame_vacuum/translations/ru.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Индивидуальная уборка"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Глубокая уборка"
+      },
       "auto_dust_collecting": {
         "name": "Автовыгрузка мусора"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Самоочистка"
+      },
+      "deep_mop_washing": {
+        "name": "Глубокая мойка швабры"
       },
       "hot_washing": {
         "name": "Мойка горячей водой"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "УФ-стерилизация"
       },
+      "customized_carpet_cleaning": {
+        "name": "Индивидуальная уборка"
+      },
       "carpet_avoidance": {
         "name": "Избегать ковров"
+      },
+      "carpet_preferences": {
+        "name": "Индивидуальные настройки"
       },
       "auto_change_mop": {
         "name": "Автосмена швабры"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Умная мойка швабры"
+      },
+      "wider_corner_coverage": {
+        "name": "Более широкий охват углов"
       },
       "pressurized_cleaning": {
         "name": "Уборка под давлением"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "Режим «Не беспокоить»"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Глубокая уборка"
-      },
-      "deep_mop_washing": {
-        "name": "Глубокая мойка швабры"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Индивидуальная уборка"
-      },
-      "carpet_preferences": {
-        "name": "Индивидуальные настройки"
-      },
-      "wider_corner_coverage": {
-        "name": "Более широкий охват углов"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/ru.json
+++ b/custom_components/dreame_vacuum/translations/ru.json
@@ -1303,15 +1303,9 @@
         "name": "Очистка колес"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Индивидуальная уборка"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Глубокая уборка"
       },
       "auto_dust_collecting": {
         "name": "Автовыгрузка мусора"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Самоочистка"
-      },
-      "deep_mop_washing": {
-        "name": "Глубокая мойка швабры"
       },
       "hot_washing": {
         "name": "Мойка горячей водой"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "УФ-стерилизация"
       },
-      "customized_carpet_cleaning": {
-        "name": "Индивидуальная уборка"
-      },
       "carpet_avoidance": {
         "name": "Избегать ковров"
-      },
-      "carpet_preferences": {
-        "name": "Индивидуальные настройки"
       },
       "auto_change_mop": {
         "name": "Автосмена швабры"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Умная мойка швабры"
-      },
-      "wider_corner_coverage": {
-        "name": "Более широкий охват углов"
       },
       "pressurized_cleaning": {
         "name": "Уборка под давлением"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "Режим «Не беспокоить»"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Глубокая уборка"
+      },
+      "deep_mop_washing": {
+        "name": "Глубокая мойка швабры"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Индивидуальная уборка"
+      },
+      "carpet_preferences": {
+        "name": "Индивидуальные настройки"
+      },
+      "wider_corner_coverage": {
+        "name": "Более широкий охват углов"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/sk.json
+++ b/custom_components/dreame_vacuum/translations/sk.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Prispôsobené čistenie"
       },
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Hlboké čistenie"
+      },
       "auto_dust_collecting": {
         "name": "Automatické vyprázdňovanie"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Samočistenie"
+      },
+      "deep_mop_washing": {
+        "name": "Hlboké umývanie mopu"
       },
       "hot_washing": {
         "name": "Umývanie horúcou vodou"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV sterilizácia"
       },
+      "customized_carpet_cleaning": {
+        "name": "Prispôsobené čistenie"
+      },
       "carpet_avoidance": {
         "name": "Vyhýbanie sa kobercom"
+      },
+      "carpet_preferences": {
+        "name": "Prispôsobené predvoľby"
       },
       "auto_change_mop": {
         "name": "Automatická výmena mopu"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Inteligentné umývanie mopu"
+      },
+      "wider_corner_coverage": {
+        "name": "Širšie pokrytie rohov"
       },
       "pressurized_cleaning": {
         "name": "Tlakové čistenie"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "DnD"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Hlboké čistenie"
-      },
-      "deep_mop_washing": {
-        "name": "Hlboké umývanie mopu"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Prispôsobené čistenie"
-      },
-      "carpet_preferences": {
-        "name": "Prispôsobené predvoľby"
-      },
-      "wider_corner_coverage": {
-        "name": "Širšie pokrytie rohov"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/sk.json
+++ b/custom_components/dreame_vacuum/translations/sk.json
@@ -1303,15 +1303,9 @@
         "name": "Čistenie kolies"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Prispôsobené čistenie"
-      },
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Hlboké čistenie"
       },
       "auto_dust_collecting": {
         "name": "Automatické vyprázdňovanie"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Samočistenie"
-      },
-      "deep_mop_washing": {
-        "name": "Hlboké umývanie mopu"
       },
       "hot_washing": {
         "name": "Umývanie horúcou vodou"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV sterilizácia"
       },
-      "customized_carpet_cleaning": {
-        "name": "Prispôsobené čistenie"
-      },
       "carpet_avoidance": {
         "name": "Vyhýbanie sa kobercom"
-      },
-      "carpet_preferences": {
-        "name": "Prispôsobené predvoľby"
       },
       "auto_change_mop": {
         "name": "Automatická výmena mopu"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Inteligentné umývanie mopu"
-      },
-      "wider_corner_coverage": {
-        "name": "Širšie pokrytie rohov"
       },
       "pressurized_cleaning": {
         "name": "Tlakové čistenie"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "DnD"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Hlboké čistenie"
+      },
+      "deep_mop_washing": {
+        "name": "Hlboké umývanie mopu"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Prispôsobené čistenie"
+      },
+      "carpet_preferences": {
+        "name": "Prispôsobené predvoľby"
+      },
+      "wider_corner_coverage": {
+        "name": "Širšie pokrytie rohov"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/sl.json
+++ b/custom_components/dreame_vacuum/translations/sl.json
@@ -1303,15 +1303,9 @@
         "name": "Čiščenje koles"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Prilagojeno čiščenje"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Globinsko čiščenje"
       },
       "auto_dust_collecting": {
         "name": "Samodejno praznjenje"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Samočiščenje"
-      },
-      "deep_mop_washing": {
-        "name": "Globinsko pranje krpe"
       },
       "hot_washing": {
         "name": "Pranje z vročo vodo"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV sterilizacija"
       },
-      "customized_carpet_cleaning": {
-        "name": "Prilagojeno čiščenje"
-      },
       "carpet_avoidance": {
         "name": "Izogibanje preprogam"
-      },
-      "carpet_preferences": {
-        "name": "Prilagojene nastavitve"
       },
       "auto_change_mop": {
         "name": "Samodejna menjava krpe"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Pametno pranje krpe"
-      },
-      "wider_corner_coverage": {
-        "name": "Širša pokritost kotov"
       },
       "pressurized_cleaning": {
         "name": "Čiščenje pod pritiskom"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "Ne moti"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Globinsko čiščenje"
+      },
+      "deep_mop_washing": {
+        "name": "Globinsko pranje krpe"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Prilagojeno čiščenje"
+      },
+      "carpet_preferences": {
+        "name": "Prilagojene nastavitve"
+      },
+      "wider_corner_coverage": {
+        "name": "Širša pokritost kotov"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/sl.json
+++ b/custom_components/dreame_vacuum/translations/sl.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Prilagojeno čiščenje"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Globinsko čiščenje"
+      },
       "auto_dust_collecting": {
         "name": "Samodejno praznjenje"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Samočiščenje"
+      },
+      "deep_mop_washing": {
+        "name": "Globinsko pranje krpe"
       },
       "hot_washing": {
         "name": "Pranje z vročo vodo"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV sterilizacija"
       },
+      "customized_carpet_cleaning": {
+        "name": "Prilagojeno čiščenje"
+      },
       "carpet_avoidance": {
         "name": "Izogibanje preprogam"
+      },
+      "carpet_preferences": {
+        "name": "Prilagojene nastavitve"
       },
       "auto_change_mop": {
         "name": "Samodejna menjava krpe"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Pametno pranje krpe"
+      },
+      "wider_corner_coverage": {
+        "name": "Širša pokritost kotov"
       },
       "pressurized_cleaning": {
         "name": "Čiščenje pod pritiskom"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "Ne moti"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Globinsko čiščenje"
-      },
-      "deep_mop_washing": {
-        "name": "Globinsko pranje krpe"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Prilagojeno čiščenje"
-      },
-      "carpet_preferences": {
-        "name": "Prilagojene nastavitve"
-      },
-      "wider_corner_coverage": {
-        "name": "Širša pokritost kotov"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/sv.json
+++ b/custom_components/dreame_vacuum/translations/sv.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Anpassad städning"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Djupstötning"
+      },
       "auto_dust_collecting": {
         "name": "Automatisk tömning"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Självrengöring"
+      },
+      "deep_mop_washing": {
+        "name": "Djup mopptvätt"
       },
       "hot_washing": {
         "name": "Varmvattentvätt"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV-sterilisering"
       },
+      "customized_carpet_cleaning": {
+        "name": "Anpassad städning"
+      },
       "carpet_avoidance": {
         "name": "Undvik mattor"
+      },
+      "carpet_preferences": {
+        "name": "Anpassade preferenser"
       },
       "auto_change_mop": {
         "name": "Automatiskt moppbyte"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Smart mopptvätt"
+      },
+      "wider_corner_coverage": {
+        "name": "Bredare hörntäckning"
       },
       "pressurized_cleaning": {
         "name": "Trycksatt städning"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "Stör ej"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Djupstötning"
-      },
-      "deep_mop_washing": {
-        "name": "Djup mopptvätt"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Anpassad städning"
-      },
-      "carpet_preferences": {
-        "name": "Anpassade preferenser"
-      },
-      "wider_corner_coverage": {
-        "name": "Bredare hörntäckning"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/sv.json
+++ b/custom_components/dreame_vacuum/translations/sv.json
@@ -1303,15 +1303,9 @@
         "name": "Hjulrengöring"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Anpassad städning"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Djupstötning"
       },
       "auto_dust_collecting": {
         "name": "Automatisk tömning"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Självrengöring"
-      },
-      "deep_mop_washing": {
-        "name": "Djup mopptvätt"
       },
       "hot_washing": {
         "name": "Varmvattentvätt"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV-sterilisering"
       },
-      "customized_carpet_cleaning": {
-        "name": "Anpassad städning"
-      },
       "carpet_avoidance": {
         "name": "Undvik mattor"
-      },
-      "carpet_preferences": {
-        "name": "Anpassade preferenser"
       },
       "auto_change_mop": {
         "name": "Automatiskt moppbyte"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Smart mopptvätt"
-      },
-      "wider_corner_coverage": {
-        "name": "Bredare hörntäckning"
       },
       "pressurized_cleaning": {
         "name": "Trycksatt städning"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "Stör ej"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Djupstötning"
+      },
+      "deep_mop_washing": {
+        "name": "Djup mopptvätt"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Anpassad städning"
+      },
+      "carpet_preferences": {
+        "name": "Anpassade preferenser"
+      },
+      "wider_corner_coverage": {
+        "name": "Bredare hörntäckning"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/th.json
+++ b/custom_components/dreame_vacuum/translations/th.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "ทำความสะอาดที่กำหนดเอง"
       },
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "ทำความสะอาดล้ำลึก"
+      },
       "auto_dust_collecting": {
         "name": "ทิ้งฝุ่นอัตโนมัติ"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "ทำความสะอาดตัวเอง"
+      },
+      "deep_mop_washing": {
+        "name": "ซักแผ่นถูล้ำลึก"
       },
       "hot_washing": {
         "name": "ซักด้วยน้ำร้อน"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "การฆ่าเชื้อด้วย UV"
       },
+      "customized_carpet_cleaning": {
+        "name": "ทำความสะอาดที่กำหนดเอง"
+      },
       "carpet_avoidance": {
         "name": "หลีกเลี่ยงพรม"
+      },
+      "carpet_preferences": {
+        "name": "การตั้งค่าที่กำหนดเอง"
       },
       "auto_change_mop": {
         "name": "เปลี่ยนแผ่นถูอัตโนมัติ"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "ซักแผ่นถูสมาร์ท"
+      },
+      "wider_corner_coverage": {
+        "name": "ครอบคลุมมุมกว้างขึ้น"
       },
       "pressurized_cleaning": {
         "name": "ทำความสะอาดแบบเพิ่มแรงดัน"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "ห้ามรบกวน (DnD)"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "ทำความสะอาดล้ำลึก"
-      },
-      "deep_mop_washing": {
-        "name": "ซักแผ่นถูล้ำลึก"
-      },
-      "customized_carpet_cleaning": {
-        "name": "ทำความสะอาดที่กำหนดเอง"
-      },
-      "carpet_preferences": {
-        "name": "การตั้งค่าที่กำหนดเอง"
-      },
-      "wider_corner_coverage": {
-        "name": "ครอบคลุมมุมกว้างขึ้น"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/th.json
+++ b/custom_components/dreame_vacuum/translations/th.json
@@ -1303,15 +1303,9 @@
         "name": "การทำความสะอาดล้อ"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "ทำความสะอาดที่กำหนดเอง"
-      },
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "ทำความสะอาดล้ำลึก"
       },
       "auto_dust_collecting": {
         "name": "ทิ้งฝุ่นอัตโนมัติ"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "ทำความสะอาดตัวเอง"
-      },
-      "deep_mop_washing": {
-        "name": "ซักแผ่นถูล้ำลึก"
       },
       "hot_washing": {
         "name": "ซักด้วยน้ำร้อน"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "การฆ่าเชื้อด้วย UV"
       },
-      "customized_carpet_cleaning": {
-        "name": "ทำความสะอาดที่กำหนดเอง"
-      },
       "carpet_avoidance": {
         "name": "หลีกเลี่ยงพรม"
-      },
-      "carpet_preferences": {
-        "name": "การตั้งค่าที่กำหนดเอง"
       },
       "auto_change_mop": {
         "name": "เปลี่ยนแผ่นถูอัตโนมัติ"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "ซักแผ่นถูสมาร์ท"
-      },
-      "wider_corner_coverage": {
-        "name": "ครอบคลุมมุมกว้างขึ้น"
       },
       "pressurized_cleaning": {
         "name": "ทำความสะอาดแบบเพิ่มแรงดัน"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "ห้ามรบกวน (DnD)"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "ทำความสะอาดล้ำลึก"
+      },
+      "deep_mop_washing": {
+        "name": "ซักแผ่นถูล้ำลึก"
+      },
+      "customized_carpet_cleaning": {
+        "name": "ทำความสะอาดที่กำหนดเอง"
+      },
+      "carpet_preferences": {
+        "name": "การตั้งค่าที่กำหนดเอง"
+      },
+      "wider_corner_coverage": {
+        "name": "ครอบคลุมมุมกว้างขึ้น"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/tr.json
+++ b/custom_components/dreame_vacuum/translations/tr.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Özelleştirilmiş Temizlik"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Derin Temizlik"
+      },
       "auto_dust_collecting": {
         "name": "Otomatik Boşaltma"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Kendi Kendine Temizlik"
+      },
+      "deep_mop_washing": {
+        "name": "Derin Mop Yıkama"
       },
       "hot_washing": {
         "name": "Sıcak Yıkama"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV Sterilizasyon"
       },
+      "customized_carpet_cleaning": {
+        "name": "Özelleştirilmiş Temizlik"
+      },
       "carpet_avoidance": {
         "name": "Halıdan Kaçınma"
+      },
+      "carpet_preferences": {
+        "name": "Özelleştirilmiş Tercihler"
       },
       "auto_change_mop": {
         "name": "Otomatik Mop Değişimi"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Akıllı Mop Yıkama"
+      },
+      "wider_corner_coverage": {
+        "name": "Geniş Köşe Kapsamı"
       },
       "pressurized_cleaning": {
         "name": "Basınçlı Temizlik"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "Rahatsız Etme (DnD)"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Derin Temizlik"
-      },
-      "deep_mop_washing": {
-        "name": "Derin Mop Yıkama"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Özelleştirilmiş Temizlik"
-      },
-      "carpet_preferences": {
-        "name": "Özelleştirilmiş Tercihler"
-      },
-      "wider_corner_coverage": {
-        "name": "Geniş Köşe Kapsamı"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/tr.json
+++ b/custom_components/dreame_vacuum/translations/tr.json
@@ -1303,15 +1303,9 @@
         "name": "Tekerlek Temizliği"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Özelleştirilmiş Temizlik"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Derin Temizlik"
       },
       "auto_dust_collecting": {
         "name": "Otomatik Boşaltma"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Kendi Kendine Temizlik"
-      },
-      "deep_mop_washing": {
-        "name": "Derin Mop Yıkama"
       },
       "hot_washing": {
         "name": "Sıcak Yıkama"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV Sterilizasyon"
       },
-      "customized_carpet_cleaning": {
-        "name": "Özelleştirilmiş Temizlik"
-      },
       "carpet_avoidance": {
         "name": "Halıdan Kaçınma"
-      },
-      "carpet_preferences": {
-        "name": "Özelleştirilmiş Tercihler"
       },
       "auto_change_mop": {
         "name": "Otomatik Mop Değişimi"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Akıllı Mop Yıkama"
-      },
-      "wider_corner_coverage": {
-        "name": "Geniş Köşe Kapsamı"
       },
       "pressurized_cleaning": {
         "name": "Basınçlı Temizlik"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "Rahatsız Etme (DnD)"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Derin Temizlik"
+      },
+      "deep_mop_washing": {
+        "name": "Derin Mop Yıkama"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Özelleştirilmiş Temizlik"
+      },
+      "carpet_preferences": {
+        "name": "Özelleştirilmiş Tercihler"
+      },
+      "wider_corner_coverage": {
+        "name": "Geniş Köşe Kapsamı"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/uk.json
+++ b/custom_components/dreame_vacuum/translations/uk.json
@@ -1303,15 +1303,9 @@
         "name": "Очищення коліс"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Індивідуальне прибирання"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Ретельне прибирання"
       },
       "auto_dust_collecting": {
         "name": "Автоматичне вивантаження сміття"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Самоочищення"
-      },
-      "deep_mop_washing": {
-        "name": "Ретельне миття швабри"
       },
       "hot_washing": {
         "name": "Миття гарячою водою"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "УФ-стерилізація"
       },
-      "customized_carpet_cleaning": {
-        "name": "Індивідуальне прибирання"
-      },
       "carpet_avoidance": {
         "name": "Уникати килимів"
-      },
-      "carpet_preferences": {
-        "name": "Індивідуальні налаштування"
       },
       "auto_change_mop": {
         "name": "Автозміна швабри"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Розумне миття швабри"
-      },
-      "wider_corner_coverage": {
-        "name": "Ширше охоплення кутів"
       },
       "pressurized_cleaning": {
         "name": "Прибирання під тиском"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "Режим «Не турбувати»"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Ретельне прибирання"
+      },
+      "deep_mop_washing": {
+        "name": "Ретельне миття швабри"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Індивідуальне прибирання"
+      },
+      "carpet_preferences": {
+        "name": "Індивідуальні налаштування"
+      },
+      "wider_corner_coverage": {
+        "name": "Ширше охоплення кутів"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/uk.json
+++ b/custom_components/dreame_vacuum/translations/uk.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Індивідуальне прибирання"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "Ретельне прибирання"
+      },
       "auto_dust_collecting": {
         "name": "Автоматичне вивантаження сміття"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Самоочищення"
+      },
+      "deep_mop_washing": {
+        "name": "Ретельне миття швабри"
       },
       "hot_washing": {
         "name": "Миття гарячою водою"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "УФ-стерилізація"
       },
+      "customized_carpet_cleaning": {
+        "name": "Індивідуальне прибирання"
+      },
       "carpet_avoidance": {
         "name": "Уникати килимів"
+      },
+      "carpet_preferences": {
+        "name": "Індивідуальні налаштування"
       },
       "auto_change_mop": {
         "name": "Автозміна швабри"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Розумне миття швабри"
+      },
+      "wider_corner_coverage": {
+        "name": "Ширше охоплення кутів"
       },
       "pressurized_cleaning": {
         "name": "Прибирання під тиском"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "Режим «Не турбувати»"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "Ретельне прибирання"
-      },
-      "deep_mop_washing": {
-        "name": "Ретельне миття швабри"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Індивідуальне прибирання"
-      },
-      "carpet_preferences": {
-        "name": "Індивідуальні налаштування"
-      },
-      "wider_corner_coverage": {
-        "name": "Ширше охоплення кутів"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/vi.json
+++ b/custom_components/dreame_vacuum/translations/vi.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "Làm sạch tùy chỉnh"
       },
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Làm sạch sâu"
+      },
       "auto_dust_collecting": {
         "name": "Tự động đổ rác"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "Tự làm sạch"
+      },
+      "deep_mop_washing": {
+        "name": "Giặt giẻ lau sâu"
       },
       "hot_washing": {
         "name": "Giặt nước nóng"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "Khử trùng bằng tia UV"
       },
+      "customized_carpet_cleaning": {
+        "name": "Làm sạch tùy chỉnh"
+      },
       "carpet_avoidance": {
         "name": "Tránh thảm"
+      },
+      "carpet_preferences": {
+        "name": "Sở thích tùy chỉnh"
       },
       "auto_change_mop": {
         "name": "Tự động thay giẻ lau"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "Giặt giẻ lau thông minh"
+      },
+      "wider_corner_coverage": {
+        "name": "Độ bao phủ góc rộng hơn"
       },
       "pressurized_cleaning": {
         "name": "Làm sạch có áp lực"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "Chế độ không làm phiền (DnD)"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Làm sạch sâu"
-      },
-      "deep_mop_washing": {
-        "name": "Giặt giẻ lau sâu"
-      },
-      "customized_carpet_cleaning": {
-        "name": "Làm sạch tùy chỉnh"
-      },
-      "carpet_preferences": {
-        "name": "Sở thích tùy chỉnh"
-      },
-      "wider_corner_coverage": {
-        "name": "Độ bao phủ góc rộng hơn"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/vi.json
+++ b/custom_components/dreame_vacuum/translations/vi.json
@@ -1303,15 +1303,9 @@
         "name": "Vệ sinh bánh xe"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "Làm sạch tùy chỉnh"
-      },
-      "cleangenius_cleaning": {
-        "name": "Cleangenius"
-      },
-      "deep_cleaning": {
-        "name": "Làm sạch sâu"
       },
       "auto_dust_collecting": {
         "name": "Tự động đổ rác"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "Tự làm sạch"
-      },
-      "deep_mop_washing": {
-        "name": "Giặt giẻ lau sâu"
       },
       "hot_washing": {
         "name": "Giặt nước nóng"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "Khử trùng bằng tia UV"
       },
-      "customized_carpet_cleaning": {
-        "name": "Làm sạch tùy chỉnh"
-      },
       "carpet_avoidance": {
         "name": "Tránh thảm"
-      },
-      "carpet_preferences": {
-        "name": "Sở thích tùy chỉnh"
       },
       "auto_change_mop": {
         "name": "Tự động thay giẻ lau"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "Giặt giẻ lau thông minh"
-      },
-      "wider_corner_coverage": {
-        "name": "Độ bao phủ góc rộng hơn"
       },
       "pressurized_cleaning": {
         "name": "Làm sạch có áp lực"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "Chế độ không làm phiền (DnD)"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "Cleangenius"
+      },
+      "deep_cleaning": {
+        "name": "Làm sạch sâu"
+      },
+      "deep_mop_washing": {
+        "name": "Giặt giẻ lau sâu"
+      },
+      "customized_carpet_cleaning": {
+        "name": "Làm sạch tùy chỉnh"
+      },
+      "carpet_preferences": {
+        "name": "Sở thích tùy chỉnh"
+      },
+      "wider_corner_coverage": {
+        "name": "Độ bao phủ góc rộng hơn"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/zh-Hans.json
+++ b/custom_components/dreame_vacuum/translations/zh-Hans.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "定制清洁"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "精细清洁"
+      },
       "auto_dust_collecting": {
         "name": "自动集尘"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "自清洁"
+      },
+      "deep_mop_washing": {
+        "name": "精细洗抹布"
       },
       "hot_washing": {
         "name": "热水洗"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV 杀菌"
       },
+      "customized_carpet_cleaning": {
+        "name": "定制清洁"
+      },
       "carpet_avoidance": {
         "name": "规避地毯"
+      },
+      "carpet_preferences": {
+        "name": "个性化偏好"
       },
       "auto_change_mop": {
         "name": "自动换抹布"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "智能洗抹布"
+      },
+      "wider_corner_coverage": {
+        "name": "边角覆盖增强"
       },
       "pressurized_cleaning": {
         "name": "加压清洁"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "勿扰"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "精细清洁"
-      },
-      "deep_mop_washing": {
-        "name": "精细洗抹布"
-      },
-      "customized_carpet_cleaning": {
-        "name": "定制清洁"
-      },
-      "carpet_preferences": {
-        "name": "个性化偏好"
-      },
-      "wider_corner_coverage": {
-        "name": "边角覆盖增强"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/zh-Hans.json
+++ b/custom_components/dreame_vacuum/translations/zh-Hans.json
@@ -1303,15 +1303,9 @@
         "name": "轮子清洁"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "定制清洁"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "精细清洁"
       },
       "auto_dust_collecting": {
         "name": "自动集尘"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "自清洁"
-      },
-      "deep_mop_washing": {
-        "name": "精细洗抹布"
       },
       "hot_washing": {
         "name": "热水洗"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV 杀菌"
       },
-      "customized_carpet_cleaning": {
-        "name": "定制清洁"
-      },
       "carpet_avoidance": {
         "name": "规避地毯"
-      },
-      "carpet_preferences": {
-        "name": "个性化偏好"
       },
       "auto_change_mop": {
         "name": "自动换抹布"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "智能洗抹布"
-      },
-      "wider_corner_coverage": {
-        "name": "边角覆盖增强"
       },
       "pressurized_cleaning": {
         "name": "加压清洁"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "勿扰"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "精细清洁"
+      },
+      "deep_mop_washing": {
+        "name": "精细洗抹布"
+      },
+      "customized_carpet_cleaning": {
+        "name": "定制清洁"
+      },
+      "carpet_preferences": {
+        "name": "个性化偏好"
+      },
+      "wider_corner_coverage": {
+        "name": "边角覆盖增强"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/zh-Hant.json
+++ b/custom_components/dreame_vacuum/translations/zh-Hant.json
@@ -1307,6 +1307,12 @@
       "customized_cleaning": {
         "name": "定制清潔"
       },
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "精細清潔"
+      },
       "auto_dust_collecting": {
         "name": "自動集塵"
       },
@@ -1315,6 +1321,9 @@
       },
       "self_clean": {
         "name": "自清潔"
+      },
+      "deep_mop_washing": {
+        "name": "精細洗抹布"
       },
       "hot_washing": {
         "name": "熱水洗"
@@ -1328,8 +1337,14 @@
       "uv_sterilization": {
         "name": "UV 殺菌"
       },
+      "customized_carpet_cleaning": {
+        "name": "定制清潔"
+      },
       "carpet_avoidance": {
         "name": "規避地毯"
+      },
+      "carpet_preferences": {
+        "name": "個性化偏好"
       },
       "auto_change_mop": {
         "name": "自動換抹布"
@@ -1387,6 +1402,9 @@
       },
       "smart_mop_washing": {
         "name": "智能洗抹布"
+      },
+      "wider_corner_coverage": {
+        "name": "邊角覆蓋增強"
       },
       "pressurized_cleaning": {
         "name": "加壓清潔"
@@ -1456,26 +1474,6 @@
       },
       "dnd": {
         "name": "勿擾"
-      }
-    },
-    "toggle": {
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "精細清潔"
-      },
-      "deep_mop_washing": {
-        "name": "精細洗抹布"
-      },
-      "customized_carpet_cleaning": {
-        "name": "定制清潔"
-      },
-      "carpet_preferences": {
-        "name": "個性化偏好"
-      },
-      "wider_corner_coverage": {
-        "name": "邊角覆蓋增強"
       }
     },
     "number": {

--- a/custom_components/dreame_vacuum/translations/zh-Hant.json
+++ b/custom_components/dreame_vacuum/translations/zh-Hant.json
@@ -1303,15 +1303,9 @@
         "name": "輪子清潔"
       }
     },
-    "toggle": {
+    "switch": {
       "customized_cleaning": {
         "name": "定制清潔"
-      },
-      "cleangenius_cleaning": {
-        "name": "CleanGenius"
-      },
-      "deep_cleaning": {
-        "name": "精細清潔"
       },
       "auto_dust_collecting": {
         "name": "自動集塵"
@@ -1321,9 +1315,6 @@
       },
       "self_clean": {
         "name": "自清潔"
-      },
-      "deep_mop_washing": {
-        "name": "精細洗抹布"
       },
       "hot_washing": {
         "name": "熱水洗"
@@ -1337,14 +1328,8 @@
       "uv_sterilization": {
         "name": "UV 殺菌"
       },
-      "customized_carpet_cleaning": {
-        "name": "定制清潔"
-      },
       "carpet_avoidance": {
         "name": "規避地毯"
-      },
-      "carpet_preferences": {
-        "name": "個性化偏好"
       },
       "auto_change_mop": {
         "name": "自動換抹布"
@@ -1402,9 +1387,6 @@
       },
       "smart_mop_washing": {
         "name": "智能洗抹布"
-      },
-      "wider_corner_coverage": {
-        "name": "邊角覆蓋增強"
       },
       "pressurized_cleaning": {
         "name": "加壓清潔"
@@ -1474,6 +1456,26 @@
       },
       "dnd": {
         "name": "勿擾"
+      }
+    },
+    "toggle": {
+      "cleangenius_cleaning": {
+        "name": "CleanGenius"
+      },
+      "deep_cleaning": {
+        "name": "精細清潔"
+      },
+      "deep_mop_washing": {
+        "name": "精細洗抹布"
+      },
+      "customized_carpet_cleaning": {
+        "name": "定制清潔"
+      },
+      "carpet_preferences": {
+        "name": "個性化偏好"
+      },
+      "wider_corner_coverage": {
+        "name": "邊角覆蓋增強"
       }
     },
     "number": {


### PR DESCRIPTION
This picks up "Backend translations" from the To Do list in the README.

Entity names are never translated. `DreameVacuumEntity._set_id()` assigns `_attr_name` from the description, and HA returns `_attr_name` in `_name_internal()` before it looks at the translation key. Every entity name in the translation files has been dead weight, in all 40 languages.

The switch names have a second problem: they sit under `entity.toggle`, but HA builds the lookup path from the entity domain, so it looks for `entity.switch` and finds nothing. Rather than rename the whole section I moved only the 51 keys that have an entity behind them. The other six (`carpet_preferences`, `cleangenius_cleaning`, `customized_carpet_cleaning`, `deep_cleaning`, `deep_mop_washing`, `wider_corner_coverage`) match no entity in the code and look like labels for the card, so they stay under `toggle` where the card would look for them. Same reasoning for `entity.input` and the `entity_component.frontend_*` sections, which I did not touch.

What this does:

- removes the `_attr_name` assignment in `_set_id()`
- splits `entity.toggle` into `entity.switch` (51 keys) and a `toggle` remainder (6 card keys), in strings.json and all 40 translation files
- adds the missing `button` (30) and `binary_sensor` (3) sections, plus keys that had no entry in `switch` (23), `sensor` (31), `number` (2) and `select` (2), to strings.json, en.json and de.json
- restores four en.json values that had lost information against the hardcoded name: `CleanGenius`, `CleanGenius Mode`, `Self-Wash Base Status`, `Auto-Add Detergent`

Other languages fall back to English for the new keys until someone translates them.

This is the first time any entity name translation takes effect, so the visible change is large. 224 names come from an entity description, and a device creates a subset of them. In German 219 change, in English 46, in every other language between 129 and 132. Entity ids stay as they are, so automations keep working, but anything matching on `friendly_name`, plus dashboard headings and voice aliases, will shift. Worth a line in the release notes.

Every entity assigns its own `entity_id` in `__init__`, most through `_generate_entity_id()`, the map, segment, shortcut and vacuum entities through `async_generate_entity_id` directly. HA then derives the object id from that entity_id via `internal_integration_suggested_object_id` and never reads the name-derived `Entity.suggested_object_id`, which matters because German is in `NATIVE_ENTITY_IDS` and would otherwise build ids from the translated name. I checked this on a fresh install in German and the ids are unchanged.

Segment, shortcut, map and vacuum entities keep their dynamic names. They either override `_set_id()` or set `_attr_name` after `super().__init__()`, so none of them go through the removed line.

For English, 46 names change because en.json already differed from the hardcoded name. 12 are casing, hyphenation or stray whitespace. The other 34 are wording: 10 consumable sensors drop the trailing `Left`, five go from `... Dirty Left` to `... Cleaning`, and 19 are unrelated rewordings such as `Fill Light` to `Camera Light` and `Cleaning Route` to `Route`. Full list below. If you would rather keep the current English names, I can align en.json to them instead.

Two pairs of entities that can coexist end up sharing a display name, both from existing entries rather than the new ones: `sensor.mop_pad` and `sensor.mop_pad_left` in 27 languages, `sensor.state` and `sensor.status` in 19. Renaming those is your call, so I left them. (`select.drying_time` and `number.drying_time` collide too, but they already do today.)

Two sensors stay English in every language. `PROPERTY_TO_NAME` gives them the keys `DIRTY_WATER_CHANNEL_DIRTY_left` and `DIRTY_WATER_CHANNEL_DIRTY_time_left`, with capitals in the middle, which no translation file matches, and the `dirty_water_channel_left` entry that does exist is unreachable. Looks like a typo, but fixing it changes the unique_id, so it is not part of this PR.

<details>
<summary>English names that change</summary>

| key | before | after |
| --- | --- | --- |
| `number.auto_empty_area` | Auto Empty Area | Auto-Empty Area |
| `number.self_clean_area` | Self Clean Area | Self-Clean Area |
| `number.self_clean_time` | Self Clean Time | Self-Clean Time |
| `number.wetness_level` | Wetness Level | Wetness |
| `select.auto_empty_frequency` | Auto Empty Frequency | Auto-Empty Frequency |
| `select.auto_empty_mode` | Auto Empty Mode | Auto-Empty Mode |
| `select.cleaning_route` | Cleaning Route | Route |
| `select.low_lying_area_frequency` | Low Lying Area Frequency | Low-Lying Area Frequency |
| `select.mop_clean_frequency` | Mop Clean Frequency | Mop Cleaning Frequency |
| `select.mop_wash_level` | Mop Wash Level | Mop Washing Mode |
| `select.self_clean_frequency` | Self Clean Frequency | Self-Clean Frequency |
| `select.washing_mode` | Washing Mode | Mop Washing Mode |
| `sensor.deodorizer_left` | Deodorizer Left | Deodorizer |
| `sensor.detergent_left` | Detergent Left | Detergent |
| `sensor.filter_left` | Filter Left | Filter |
| `sensor.fluffing_roller_dirty_left` | Fluffing Roller Dirty Left | Fluffing Roller Cleaning |
| `sensor.main_brush_left` | Main Brush Left | Main Brush |
| `sensor.main_brush_time_left` | Main Brush  Time Left | Main Brush Time Left |
| `sensor.mop_pad_left` | Mop Pad Left | Mop Pad |
| `sensor.onboard_dirty_water_tank_left` | Onboard Dirty Water Tank Left | Onboard Dirty Water Tank |
| `sensor.roller_mop_filter_dirty_left` | Roller Mop Filter Dirty Left | Roller Mop Filter Cleaning |
| `sensor.scale_inhibitor_left` | Scale Inhibitor Left | Scale Inhibitor |
| `sensor.sensor_dirty_left` | Sensor Dirty Left | Sensor Cleaning |
| `sensor.side_brush_left` | Side Brush Left | Side Brush |
| `sensor.silver_ion_left` | Silver-ion Left | Silver Ion |
| `sensor.squeegee_left` | Squeegee Left | Squeegee |
| `sensor.tank_filter_left` | Tank Filter Left | Tank Filter |
| `sensor.water_outlet_filter_dirty_left` | Water Outlet Filter Dirty Left | Water Outlet Filter Cleaning |
| `sensor.wheel_dirty_left` | Wheel Dirty Left | Wheel Cleaning |
| `switch.ai_obstacle_picture` | AI Obstacle Picture | Obstacle Pictures |
| `switch.ai_pet_detection` | AI Pet Detection | Pet Detection |
| `switch.auto_change_mop` | Auto Change Mop | Auto Mop Changing |
| `switch.auto_dust_collecting` | Auto Dust Collecting | Auto-Empty |
| `switch.auto_mount_mop` | Auto Mount Mop | Auto Mop Mounting |
| `switch.close_roller_cover_on_carpet` | Close Roller Cover On Carpet | Close Roller Cover on Carpet |
| `switch.dnd_disable_auto_empty` | DnD Disable Auto Empty | Disable Auto Empty |
| `switch.dnd_disable_resume_cleaning` | DnD Disable Resume Cleaning | Disable Resume Cleaning |
| `switch.dnd_reduce_volume` | DnD Reduce Volume | Reduce Volume |
| `switch.fill_light` | Fill Light | Camera Light |
| `switch.lift_chassis_on_carpet` | Lift Chassis On Carpet | Lift Chassis on Carpet |
| `switch.mop_washing_with_detergent` | Mop Washing With Detergent | Mop-Washing With Detergent |
| `switch.multi_floor_map` | Multi Floor Map | Multi-Floor Map |
| `time.dnd_end` | DnD End | DnD End Time |
| `time.dnd_start` | DnD Start | DnD Start Time |
| `time.off_peak_charging_end` | Off-Peak Charging End | Off-Peak End Time |
| `time.off_peak_charging_start` | Off-Peak Charging Start | Off-Peak Start Time |

</details>
